### PR TITLE
Emit `bindgen_original_name` attributes for nested types

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2008,6 +2008,11 @@ impl CodeGenerator for CompInfo {
             attributes.push(attributes::derives(&derives))
         }
 
+        let original_name = item.original_name(ctx);
+        if canonical_name != original_name {
+            attributes.push(attributes::original_name(&original_name));
+        }
+
         let mut tokens = if is_union && struct_layout.is_rust_union() {
             quote! {
                 #( #attributes )*

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -12,6 +12,7 @@ pub struct A {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("A::B")]
 pub struct A_B {
     pub member_b: ::std::os::raw::c_int,
 }
@@ -42,6 +43,7 @@ fn bindgen_test_layout_A_B() {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("A::D")]
 pub struct A_D<T> {
     pub foo: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
@@ -76,6 +78,7 @@ fn bindgen_test_layout_A() {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("A::C")]
 pub struct A_C {
     pub baz: ::std::os::raw::c_int,
 }
@@ -153,6 +156,7 @@ pub struct Templated<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("Templated::Templated_inner")]
 pub struct Templated_Templated_inner<T> {
     pub member_ptr: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,

--- a/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -12,24 +12,28 @@ pub struct foo {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("foo::bar1")]
 pub struct bar1 {
     pub x1: ::std::os::raw::c_int,
     pub b2: bar1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("foo::bar1::_bindgen_ty_1")]
 pub struct bar1__bindgen_ty_1 {
     pub x2: ::std::os::raw::c_int,
     pub b3: bar1__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("foo::bar1::_bindgen_ty_1::_bindgen_ty_1")]
 pub struct bar1__bindgen_ty_1__bindgen_ty_1 {
     pub x3: ::std::os::raw::c_int,
     pub b4: bar4,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("foo::bar1::_bindgen_ty_1::_bindgen_ty_1::bar4")]
 pub struct bar4 {
     pub x4: ::std::os::raw::c_int,
 }
@@ -180,11 +184,13 @@ pub struct _bindgen_ty_1 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("_bindgen_ty_1::_bindgen_ty_1")]
 pub struct _bindgen_ty_1__bindgen_ty_1 {
     pub b: baz,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("_bindgen_ty_1::_bindgen_ty_1::baz")]
 pub struct baz {
     pub x: ::std::os::raw::c_int,
 }

--- a/tests/expectations/tests/nested.rs
+++ b/tests/expectations/tests/nested.rs
@@ -35,12 +35,14 @@ pub struct Test {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("Test::Size")]
 pub struct Test_Size {
     pub mWidth: Test_Size_Dimension,
     pub mHeight: Test_Size_Dimension,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("Test::Size::Dimension")]
 pub struct Test_Size_Dimension {
     pub _base: Calc,
 }

--- a/tests/expectations/tests/nested_within_namespace.rs
+++ b/tests/expectations/tests/nested_within_namespace.rs
@@ -19,6 +19,7 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
+        #[bindgen_original_name("Bar::Baz")]
         pub struct Bar_Baz {
             pub foo: ::std::os::raw::c_int,
         }

--- a/tests/parse_callbacks/mod.rs
+++ b/tests/parse_callbacks/mod.rs
@@ -1,4 +1,4 @@
-use bindgen::callbacks::*;
+use crate::bindgen::callbacks::*;
 
 #[derive(Debug)]
 struct EnumVariantRename;


### PR DESCRIPTION
This is needed to allow autocxx to use the correct C++ name of the nested type in generated code. See google/autocxx#115 for details.

I've updated some tests with the expected attributes. Hopefully, I've caught all tests that need updating; not all tests currently pass, and I didn't want to update the expected output for some of the tests that don't pass because I'm not sure if it's correct to do so.