### PR TITLE
Update test expectations

### DIFF
--- a/tests/expectations/tests/class_with_typedef.rs
+++ b/tests/expectations/tests/class_with_typedef.rs
@@ -66,11 +66,13 @@ extern "C" {
     pub fn C_method(this: *mut C, c: C_MyInt);
 }
 extern "C" {
+    #[bindgen_arg_type_reference(c)]
     #[bindgen_original_name("methodRef")]
     #[link_name = "\u{1}_ZN1C9methodRefERi"]
     pub fn C_methodRef(this: *mut C, c: *mut C_MyInt);
 }
 extern "C" {
+    #[bindgen_arg_type_reference(c)]
     #[bindgen_original_name("complexMethodRef")]
     #[link_name = "\u{1}_ZN1C16complexMethodRefERPKc"]
     pub fn C_complexMethodRef(this: *mut C, c: *mut C_Lookup);
@@ -90,10 +92,12 @@ impl C {
     pub unsafe fn method(&mut self, c: C_MyInt) {
         C_method(self, c)
     }
+    #[bindgen_arg_type_reference(c)]
     #[inline]
     pub unsafe fn methodRef(&mut self, c: *mut C_MyInt) {
         C_methodRef(self, c)
     }
+    #[bindgen_arg_type_reference(c)]
     #[inline]
     pub unsafe fn complexMethodRef(&mut self, c: *mut C_Lookup) {
         C_complexMethodRef(self, c)

--- a/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -5,6 +5,7 @@
     non_upper_case_globals
 )]
 
+#[bindgen_unused_template_param]
 pub type c = nsTArray;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -87,6 +88,7 @@ impl Default for nsIContent {
     }
 }
 extern "C" {
+    #[bindgen_unused_template_param_in_arg_or_return]
     #[link_name = "\u{1}_Z35Gecko_GetAnonymousContentForElementv"]
     pub fn Gecko_GetAnonymousContentForElement() -> *mut nsTArray;
 }

--- a/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
+++ b/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
@@ -30,3 +30,15 @@ impl Default for Foo {
         unsafe { ::std::mem::zeroed() }
     }
 }
+extern "C" {
+    #[bindgen_pure_virtual]
+    #[bindgen_original_name("Bar")]
+    #[link_name = "\u{1}_ZN3Foo3BarEv"]
+    pub fn Foo_Bar(this: *mut ::std::os::raw::c_void);
+}
+extern "C" {
+    #[bindgen_pure_virtual]
+    #[bindgen_original_name("Foo_destructor")]
+    #[link_name = "\u{1}_ZN3FooD1Ev"]
+    pub fn Foo_Foo_destructor(this: *mut Foo);
+}

--- a/tests/expectations/tests/issue-2019.rs
+++ b/tests/expectations/tests/issue-2019.rs
@@ -62,6 +62,7 @@ fn bindgen_test_layout_B() {
     );
 }
 extern "C" {
+    #[bindgen_original_name("make")]
     #[link_name = "\u{1}_ZN1B4makeEv"]
     pub fn make1() -> B;
 }

--- a/tests/expectations/tests/issue-833-1.rs
+++ b/tests/expectations/tests/issue-833-1.rs
@@ -11,5 +11,6 @@ pub struct nsTArray {
 }
 
 extern "C" {
+    #[bindgen_unused_template_param_in_arg_or_return]
     pub fn func() -> *mut nsTArray;
 }

--- a/tests/expectations/tests/nsBaseHashtable.rs
+++ b/tests/expectations/tests/nsBaseHashtable.rs
@@ -22,6 +22,7 @@ pub struct nsBaseHashtable {
     pub _address: u8,
 }
 pub type nsBaseHashtable_KeyType = [u8; 0usize];
+#[bindgen_unused_template_param]
 pub type nsBaseHashtable_EntryType = nsBaseHashtableET;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/tests/expectations/tests/opaque_typedef.rs
+++ b/tests/expectations/tests/opaque_typedef.rs
@@ -12,4 +12,5 @@ pub struct RandomTemplate {
 }
 /// <div rustbindgen opaque></div>
 pub type ShouldBeOpaque = u8;
+#[bindgen_unused_template_param]
 pub type ShouldNotBeOpaque = RandomTemplate;

--- a/tests/expectations/tests/ref_argument_array.rs
+++ b/tests/expectations/tests/ref_argument_array.rs
@@ -32,6 +32,7 @@ impl Default for nsID {
     }
 }
 extern "C" {
+    #[bindgen_arg_type_reference(aDest)]
     #[bindgen_original_name("ToProvidedString")]
     #[link_name = "\u{1}_ZN4nsID16ToProvidedStringERA10_c"]
     pub fn nsID_ToProvidedString(

--- a/tests/expectations/tests/template-param-usage-7.rs
+++ b/tests/expectations/tests/template-param-usage-7.rs
@@ -18,4 +18,5 @@ impl<T, V> Default for DoesNotUseU<T, V> {
         unsafe { ::std::mem::zeroed() }
     }
 }
+#[bindgen_unused_template_param]
 pub type Alias = DoesNotUseU<::std::os::raw::c_int, ::std::os::raw::c_char>;

--- a/tests/expectations/tests/templateref_opaque.rs
+++ b/tests/expectations/tests/templateref_opaque.rs
@@ -16,4 +16,5 @@ pub type detail_PointerType_Type<T> = *mut T;
 pub struct UniquePtr {
     pub _address: u8,
 }
+#[bindgen_unused_template_param]
 pub type UniquePtr_Pointer = detail_PointerType;

--- a/tests/expectations/tests/what_is_going_on.rs
+++ b/tests/expectations/tests/what_is_going_on.rs
@@ -36,4 +36,5 @@ impl<F> Default for PointTyped<F> {
         unsafe { ::std::mem::zeroed() }
     }
 }
+#[bindgen_unused_template_param]
 pub type IntPoint = PointTyped<f32>;


### PR DESCRIPTION
Test expectations have changed relative to upstream because of attributes that autocxx-bindgen adds.

Updating the expectations will make it easier to check whether any future local changes have unintended consequences.

There are two tests for which I haven't updated expectations because there is more changing than just attributes, and it looks to me as if these may be symptoms of actual bugs:

header_template_hpp
header_template_param_usage_15_hpp

I will open an issue for these.