### PR TITLE
Add attribute for C++ special members

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -683,6 +683,21 @@ impl Cursor {
         unsafe { clang_isVirtualBase(self.x) != 0 }
     }
 
+    // Is this cursor's referent a default constructor?
+    pub fn is_default_constructor(&self) -> bool {
+        unsafe { clang_CXXConstructor_isDefaultConstructor(self.x) != 0 }
+    }
+
+    // Is this cursor's referent a copy constructor?
+    pub fn is_copy_constructor(&self) -> bool {
+        unsafe { clang_CXXConstructor_isCopyConstructor(self.x) != 0 }
+    }
+
+    // Is this cursor's referent a move constructor?
+    pub fn is_move_constructor(&self) -> bool {
+        unsafe { clang_CXXConstructor_isMoveConstructor(self.x) != 0 }
+    }
+
     /// Try to evaluate this cursor.
     pub fn evaluate(&self) -> Option<EvalResult> {
         EvalResult::new(*self)

--- a/src/codegen/helpers.rs
+++ b/src/codegen/helpers.rs
@@ -6,6 +6,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::TokenStreamExt;
 
 pub mod attributes {
+    use crate::ir::comp::SpecialMemberKind;
     use proc_macro2::{Ident, Span, TokenStream};
     use std::str::FromStr;
 
@@ -102,6 +103,18 @@ pub mod attributes {
     pub fn alias_discards_template_params() -> TokenStream {
         quote! {
             #[bindgen_unused_template_param]
+        }
+    }
+
+    pub fn special_member(kind: SpecialMemberKind) -> TokenStream {
+        let kind_str = match kind {
+            SpecialMemberKind::DefaultConstructor => "default_ctor",
+            SpecialMemberKind::CopyConstructor => "copy_ctor",
+            SpecialMemberKind::MoveConstructor => "move_ctor",
+            SpecialMemberKind::Destructor => "dtor",
+        };
+        quote! {
+            #[bindgen_special_member(#kind_str)]
         }
     }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3977,6 +3977,10 @@ impl CodeGenerator for Function {
             attributes.push(attributes::original_name(self.name()));
         }
 
+        if let Some(special_member_kind) = self.special_member() {
+            attributes.push(attributes::special_member(special_member_kind));
+        }
+
         let link_name = mangled_name.unwrap_or(name);
         if !utils::names_will_be_identical_after_mangling(
             &canonical_name,

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -73,6 +73,17 @@ impl MethodKind {
     }
 }
 
+// The kind of C++ special member.
+// TODO: We don't currently cover copy assignment or move assignment operator
+// because libclang doesn't provide a way to query for them.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum SpecialMemberKind {
+    DefaultConstructor,
+    CopyConstructor,
+    MoveConstructor,
+    Destructor,
+}
+
 /// A struct representing a C++ method, either static, normal, or virtual.
 #[derive(Debug)]
 pub struct Method {

--- a/tests/expectations/tests/class_with_typedef.rs
+++ b/tests/expectations/tests/class_with_typedef.rs
@@ -66,11 +66,13 @@ extern "C" {
     pub fn C_method(this: *mut C, c: C_MyInt);
 }
 extern "C" {
+    #[bindgen_arg_type_reference(c)]
     #[bindgen_original_name("methodRef")]
     #[link_name = "\u{1}_ZN1C9methodRefERi"]
     pub fn C_methodRef(this: *mut C, c: *mut C_MyInt);
 }
 extern "C" {
+    #[bindgen_arg_type_reference(c)]
     #[bindgen_original_name("complexMethodRef")]
     #[link_name = "\u{1}_ZN1C16complexMethodRefERPKc"]
     pub fn C_complexMethodRef(this: *mut C, c: *mut C_Lookup);
@@ -90,10 +92,12 @@ impl C {
     pub unsafe fn method(&mut self, c: C_MyInt) {
         C_method(self, c)
     }
+    #[bindgen_arg_type_reference(c)]
     #[inline]
     pub unsafe fn methodRef(&mut self, c: *mut C_MyInt) {
         C_methodRef(self, c)
     }
+    #[bindgen_arg_type_reference(c)]
     #[inline]
     pub unsafe fn complexMethodRef(&mut self, c: *mut C_Lookup) {
         C_complexMethodRef(self, c)

--- a/tests/expectations/tests/constructor-tp.rs
+++ b/tests/expectations/tests/constructor-tp.rs
@@ -30,6 +30,7 @@ fn bindgen_test_layout_Bar() {
 }
 extern "C" {
     #[bindgen_original_name("Bar")]
+    #[bindgen_special_member("default_ctor")]
     #[link_name = "\u{1}_ZN3BarC1Ev"]
     pub fn Bar_Bar(this: *mut Bar);
 }

--- a/tests/expectations/tests/constructors.rs
+++ b/tests/expectations/tests/constructors.rs
@@ -70,6 +70,7 @@ fn bindgen_test_layout_TestPublicNoArgs() {
 }
 extern "C" {
     #[bindgen_original_name("TestPublicNoArgs")]
+    #[bindgen_special_member("default_ctor")]
     #[link_name = "\u{1}_ZN16TestPublicNoArgsC1Ev"]
     pub fn TestPublicNoArgs_TestPublicNoArgs(this: *mut TestPublicNoArgs);
 }

--- a/tests/expectations/tests/constructors_1_33.rs
+++ b/tests/expectations/tests/constructors_1_33.rs
@@ -72,6 +72,7 @@ fn bindgen_test_layout_TestPublicNoArgs() {
 }
 extern "C" {
     #[bindgen_original_name("TestPublicNoArgs")]
+    #[bindgen_special_member("default_ctor")]
     #[link_name = "\u{1}_ZN16TestPublicNoArgsC1Ev"]
     pub fn TestPublicNoArgs_TestPublicNoArgs(this: *mut TestPublicNoArgs);
 }

--- a/tests/expectations/tests/gen-destructors.rs
+++ b/tests/expectations/tests/gen-destructors.rs
@@ -30,6 +30,7 @@ fn bindgen_test_layout_Foo() {
 }
 extern "C" {
     #[bindgen_original_name("Foo_destructor")]
+    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN3FooD1Ev"]
     pub fn Foo_Foo_destructor(this: *mut Foo);
 }

--- a/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -5,6 +5,7 @@
     non_upper_case_globals
 )]
 
+#[bindgen_unused_template_param]
 pub type c = nsTArray;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -87,6 +88,7 @@ impl Default for nsIContent {
     }
 }
 extern "C" {
+    #[bindgen_unused_template_param_in_arg_or_return]
     #[link_name = "\u{1}_Z35Gecko_GetAnonymousContentForElementv"]
     pub fn Gecko_GetAnonymousContentForElement() -> *mut nsTArray;
 }

--- a/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
+++ b/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
@@ -30,3 +30,15 @@ impl Default for Foo {
         unsafe { ::std::mem::zeroed() }
     }
 }
+extern "C" {
+    #[bindgen_pure_virtual]
+    #[bindgen_original_name("Bar")]
+    #[link_name = "\u{1}_ZN3Foo3BarEv"]
+    pub fn Foo_Bar(this: *mut ::std::os::raw::c_void);
+}
+extern "C" {
+    #[bindgen_pure_virtual]
+    #[bindgen_original_name("Foo_destructor")]
+    #[link_name = "\u{1}_ZN3FooD1Ev"]
+    pub fn Foo_Foo_destructor(this: *mut Foo);
+}

--- a/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
+++ b/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
@@ -39,6 +39,7 @@ extern "C" {
 extern "C" {
     #[bindgen_pure_virtual]
     #[bindgen_original_name("Foo_destructor")]
+    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN3FooD1Ev"]
     pub fn Foo_Foo_destructor(this: *mut Foo);
 }

--- a/tests/expectations/tests/issue-2019.rs
+++ b/tests/expectations/tests/issue-2019.rs
@@ -62,6 +62,7 @@ fn bindgen_test_layout_B() {
     );
 }
 extern "C" {
+    #[bindgen_original_name("make")]
     #[link_name = "\u{1}_ZN1B4makeEv"]
     pub fn make1() -> B;
 }

--- a/tests/expectations/tests/issue-833-1.rs
+++ b/tests/expectations/tests/issue-833-1.rs
@@ -11,5 +11,6 @@ pub struct nsTArray {
 }
 
 extern "C" {
+    #[bindgen_unused_template_param_in_arg_or_return]
     pub fn func() -> *mut nsTArray;
 }

--- a/tests/expectations/tests/nsBaseHashtable.rs
+++ b/tests/expectations/tests/nsBaseHashtable.rs
@@ -22,6 +22,7 @@ pub struct nsBaseHashtable {
     pub _address: u8,
 }
 pub type nsBaseHashtable_KeyType = [u8; 0usize];
+#[bindgen_unused_template_param]
 pub type nsBaseHashtable_EntryType = nsBaseHashtableET;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/tests/expectations/tests/opaque_typedef.rs
+++ b/tests/expectations/tests/opaque_typedef.rs
@@ -12,4 +12,5 @@ pub struct RandomTemplate {
 }
 /// <div rustbindgen opaque></div>
 pub type ShouldBeOpaque = u8;
+#[bindgen_unused_template_param]
 pub type ShouldNotBeOpaque = RandomTemplate;

--- a/tests/expectations/tests/packed-vtable.rs
+++ b/tests/expectations/tests/packed-vtable.rs
@@ -33,6 +33,7 @@ impl Default for PackedVtable {
 }
 extern "C" {
     #[bindgen_original_name("PackedVtable_destructor")]
+    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN12PackedVtableD1Ev"]
     pub fn PackedVtable_PackedVtable_destructor(this: *mut PackedVtable);
 }

--- a/tests/expectations/tests/public-dtor.rs
+++ b/tests/expectations/tests/public-dtor.rs
@@ -25,6 +25,7 @@ fn bindgen_test_layout_cv_String() {
 }
 extern "C" {
     #[bindgen_original_name("String_destructor")]
+    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN2cv6StringD1Ev"]
     pub fn cv_String_String_destructor(this: *mut cv_String);
 }

--- a/tests/expectations/tests/ref_argument_array.rs
+++ b/tests/expectations/tests/ref_argument_array.rs
@@ -32,6 +32,7 @@ impl Default for nsID {
     }
 }
 extern "C" {
+    #[bindgen_arg_type_reference(aDest)]
     #[bindgen_original_name("ToProvidedString")]
     #[link_name = "\u{1}_ZN4nsID16ToProvidedStringERA10_c"]
     pub fn nsID_ToProvidedString(

--- a/tests/expectations/tests/special-members.rs
+++ b/tests/expectations/tests/special-members.rs
@@ -1,0 +1,77 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct A {
+    pub _address: u8,
+}
+#[test]
+fn bindgen_test_layout_A() {
+    assert_eq!(
+        ::std::mem::size_of::<A>(),
+        1usize,
+        concat!("Size of: ", stringify!(A))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<A>(),
+        1usize,
+        concat!("Alignment of ", stringify!(A))
+    );
+}
+extern "C" {
+    #[bindgen_original_name("A")]
+    #[bindgen_special_member("default_ctor")]
+    #[link_name = "\u{1}_ZN1AC1Ev"]
+    pub fn A_A(this: *mut A);
+}
+extern "C" {
+    #[bindgen_arg_type_reference(arg1)]
+    #[bindgen_original_name("A")]
+    #[bindgen_special_member("copy_ctor")]
+    #[link_name = "\u{1}_ZN1AC1ERS_"]
+    pub fn A_A1(this: *mut A, arg1: *mut A);
+}
+extern "C" {
+    #[bindgen_arg_type_reference(arg1)]
+    #[bindgen_original_name("A")]
+    #[bindgen_special_member("move_ctor")]
+    #[link_name = "\u{1}_ZN1AC1EOS_"]
+    pub fn A_A2(this: *mut A, arg1: *mut A);
+}
+extern "C" {
+    #[bindgen_original_name("A_destructor")]
+    #[bindgen_special_member("dtor")]
+    #[link_name = "\u{1}_ZN1AD1Ev"]
+    pub fn A_A_destructor(this: *mut A);
+}
+impl A {
+    #[inline]
+    pub unsafe fn new() -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        A_A(__bindgen_tmp.as_mut_ptr());
+        __bindgen_tmp.assume_init()
+    }
+    #[bindgen_arg_type_reference(arg1)]
+    #[inline]
+    pub unsafe fn new1(arg1: *mut A) -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        A_A1(__bindgen_tmp.as_mut_ptr(), arg1);
+        __bindgen_tmp.assume_init()
+    }
+    #[bindgen_arg_type_reference(arg1)]
+    #[inline]
+    pub unsafe fn new2(arg1: *mut A) -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        A_A2(__bindgen_tmp.as_mut_ptr(), arg1);
+        __bindgen_tmp.assume_init()
+    }
+    #[inline]
+    pub unsafe fn destruct(&mut self) {
+        A_A_destructor(self)
+    }
+}

--- a/tests/expectations/tests/template-param-usage-7.rs
+++ b/tests/expectations/tests/template-param-usage-7.rs
@@ -18,4 +18,5 @@ impl<T, V> Default for DoesNotUseU<T, V> {
         unsafe { ::std::mem::zeroed() }
     }
 }
+#[bindgen_unused_template_param]
 pub type Alias = DoesNotUseU<::std::os::raw::c_int, ::std::os::raw::c_char>;

--- a/tests/expectations/tests/templateref_opaque.rs
+++ b/tests/expectations/tests/templateref_opaque.rs
@@ -16,4 +16,5 @@ pub type detail_PointerType_Type<T> = *mut T;
 pub struct UniquePtr {
     pub _address: u8,
 }
+#[bindgen_unused_template_param]
 pub type UniquePtr_Pointer = detail_PointerType;

--- a/tests/expectations/tests/union_dtor.rs
+++ b/tests/expectations/tests/union_dtor.rs
@@ -49,6 +49,7 @@ fn bindgen_test_layout_UnionWithDtor() {
 }
 extern "C" {
     #[bindgen_original_name("UnionWithDtor_destructor")]
+    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]
     pub fn UnionWithDtor_UnionWithDtor_destructor(this: *mut UnionWithDtor);
 }

--- a/tests/expectations/tests/union_dtor_1_0.rs
+++ b/tests/expectations/tests/union_dtor_1_0.rs
@@ -94,6 +94,7 @@ fn bindgen_test_layout_UnionWithDtor() {
 }
 extern "C" {
     #[bindgen_original_name("UnionWithDtor_destructor")]
+    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]
     pub fn UnionWithDtor_UnionWithDtor_destructor(this: *mut UnionWithDtor);
 }

--- a/tests/expectations/tests/virtual_dtor.rs
+++ b/tests/expectations/tests/virtual_dtor.rs
@@ -32,6 +32,7 @@ impl Default for nsSlots {
 }
 extern "C" {
     #[bindgen_original_name("nsSlots_destructor")]
+    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN7nsSlotsD1Ev"]
     pub fn nsSlots_nsSlots_destructor(this: *mut nsSlots);
 }

--- a/tests/expectations/tests/what_is_going_on.rs
+++ b/tests/expectations/tests/what_is_going_on.rs
@@ -36,4 +36,5 @@ impl<F> Default for PointTyped<F> {
         unsafe { ::std::mem::zeroed() }
     }
 }
+#[bindgen_unused_template_param]
 pub type IntPoint = PointTyped<f32>;

--- a/tests/headers/special-members.hpp
+++ b/tests/headers/special-members.hpp
@@ -1,0 +1,7 @@
+class A {
+public:
+    A();
+    A(A&);
+    A(A&&);
+    ~A();
+};


### PR DESCRIPTION
See google/autocxx#456 for details.

If I was submitting this upstream, I would have put the information about special members directly in the `MethodKind` enum, but that would have been a pretty invasive change that could cause merge conflicts when merging from upstream. I've therefore decided to put add a separate enum that is used in as few places as possible.