### PR TITLE
Don't emit `bindgen_original_name` attribute for anonymous structs

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2008,9 +2008,10 @@ impl CodeGenerator for CompInfo {
             attributes.push(attributes::derives(&derives))
         }
 
-        let original_name = item.original_name(ctx);
-        if canonical_name != original_name {
-            attributes.push(attributes::original_name(&original_name));
+        if let Some(original_name) = item.original_name(ctx) {
+            if canonical_name != original_name {
+                attributes.push(attributes::original_name(&original_name));
+            }
         }
 
         let mut tokens = if is_union && struct_layout.is_rust_union() {

--- a/tests/expectations/tests/381-decltype-alias.rs
+++ b/tests/expectations/tests/381-decltype-alias.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("allocator_traits")]
 pub struct std_allocator_traits {
     pub _address: u8,
 }

--- a/tests/expectations/tests/allowlist_basic.rs
+++ b/tests/expectations/tests/allowlist_basic.rs
@@ -14,6 +14,7 @@ pub struct AllowlistMe<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("AllowlistMe::Inner")]
 pub struct AllowlistMe_Inner<T> {
     pub bar: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,

--- a/tests/expectations/tests/anon_union.rs
+++ b/tests/expectations/tests/anon_union.rs
@@ -23,11 +23,13 @@ pub enum TErrorResult_UnionState {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("TErrorResult::Message")]
 pub struct TErrorResult_Message {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("TErrorResult::DOMExceptionInfo")]
 pub struct TErrorResult_DOMExceptionInfo {
     _unused: [u8; 0],
 }

--- a/tests/expectations/tests/anon_union_1_0.rs
+++ b/tests/expectations/tests/anon_union_1_0.rs
@@ -65,11 +65,13 @@ pub enum TErrorResult_UnionState {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("TErrorResult::Message")]
 pub struct TErrorResult_Message {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("TErrorResult::DOMExceptionInfo")]
 pub struct TErrorResult_DOMExceptionInfo {
     _unused: [u8; 0],
 }

--- a/tests/expectations/tests/bad-namespace-parenthood-inheritance.rs
+++ b/tests/expectations/tests/bad-namespace-parenthood-inheritance.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("char_traits")]
 pub struct std_char_traits {
     pub _address: u8,
 }
@@ -17,6 +18,7 @@ impl Default for std_char_traits {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("char_traits")]
 pub struct __gnu_cxx_char_traits {
     pub _address: u8,
 }

--- a/tests/expectations/tests/class_with_inner_struct.rs
+++ b/tests/expectations/tests/class_with_inner_struct.rs
@@ -14,6 +14,7 @@ pub struct A {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("A::Segment")]
 pub struct A_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
@@ -167,6 +168,7 @@ pub struct B {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("B::Segment")]
 pub struct B_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
@@ -402,6 +404,7 @@ impl Default for C__bindgen_ty_1 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("C::Segment")]
 pub struct C_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -57,6 +57,7 @@ pub struct A {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
+#[bindgen_original_name("A::Segment")]
 pub struct A_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
@@ -217,6 +218,7 @@ pub struct B {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
+#[bindgen_original_name("B::Segment")]
 pub struct B_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
@@ -473,6 +475,7 @@ impl Clone for C__bindgen_ty_1 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
+#[bindgen_original_name("C::Segment")]
 pub struct C_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,

--- a/tests/expectations/tests/comment-indent.rs
+++ b/tests/expectations/tests/comment-indent.rs
@@ -22,6 +22,7 @@ pub mod root {
     /// This class is not so interesting, but worth a bit of docs too!
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
+    #[bindgen_original_name("Foo::Bar")]
     pub struct Foo_Bar {
         pub _address: u8,
     }

--- a/tests/expectations/tests/constant-non-specialized-tp.rs
+++ b/tests/expectations/tests/constant-non-specialized-tp.rs
@@ -17,6 +17,7 @@ pub struct Outer {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("Outer::Inner")]
 pub struct Outer_Inner {
     pub _address: u8,
 }

--- a/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -19,21 +19,18 @@ pub struct bar1 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("foo::bar1::_bindgen_ty_1")]
 pub struct bar1__bindgen_ty_1 {
     pub x2: ::std::os::raw::c_int,
     pub b3: bar1__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("foo::bar1::_bindgen_ty_1::_bindgen_ty_1")]
 pub struct bar1__bindgen_ty_1__bindgen_ty_1 {
     pub x3: ::std::os::raw::c_int,
     pub b4: bar4,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("foo::bar1::_bindgen_ty_1::_bindgen_ty_1::bar4")]
 pub struct bar4 {
     pub x4: ::std::os::raw::c_int,
 }
@@ -184,13 +181,11 @@ pub struct _bindgen_ty_1 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("_bindgen_ty_1::_bindgen_ty_1")]
 pub struct _bindgen_ty_1__bindgen_ty_1 {
     pub b: baz,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("_bindgen_ty_1::_bindgen_ty_1::baz")]
 pub struct baz {
     pub x: ::std::os::raw::c_int,
 }

--- a/tests/expectations/tests/enum_in_template_with_typedef.rs
+++ b/tests/expectations/tests/enum_in_template_with_typedef.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("fbstring_core")]
 pub struct std_fbstring_core {
     pub _address: u8,
 }

--- a/tests/expectations/tests/forward-inherit-struct-with-fields.rs
+++ b/tests/expectations/tests/forward-inherit-struct-with-fields.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("RootedBase")]
 pub struct js_RootedBase<T> {
     pub foo: *mut T,
     pub next: *mut Rooted<T>,

--- a/tests/expectations/tests/forward-inherit-struct.rs
+++ b/tests/expectations/tests/forward-inherit-struct.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("RootedBase")]
 pub struct js_RootedBase {
     pub _address: u8,
 }

--- a/tests/expectations/tests/in_class_typedef.rs
+++ b/tests/expectations/tests/in_class_typedef.rs
@@ -14,6 +14,7 @@ pub type Foo_elem_type<T> = T;
 pub type Foo_ptr_type<T> = *mut T;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("Foo::Bar")]
 pub struct Foo_Bar {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,

--- a/tests/expectations/tests/inherit-namespaced.rs
+++ b/tests/expectations/tests/inherit-namespaced.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("RootedBase")]
 pub struct js_RootedBase {
     pub _address: u8,
 }

--- a/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
+++ b/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug)]
+#[bindgen_original_name("basic_string")]
 pub struct std_basic_string<CharT> {
     pub hider: std_basic_string_Alloc_hider,
     pub length: ::std::os::raw::c_ulong,
@@ -15,6 +16,7 @@ pub struct std_basic_string<CharT> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("basic_string::Alloc_hider")]
 pub struct std_basic_string_Alloc_hider {
     pub storage: *mut ::std::os::raw::c_void,
 }

--- a/tests/expectations/tests/issue-1113-template-references.rs
+++ b/tests/expectations/tests/issue-1113-template-references.rs
@@ -26,6 +26,7 @@ pub struct nsBaseHashtable {
 pub type nsBaseHashtable_EntryType<K, V> = Entry<K, V>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("nsBaseHashtable::EntryPtr")]
 pub struct nsBaseHashtable_EntryPtr<K, V> {
     pub mEntry: *mut nsBaseHashtable_EntryType<K, V>,
     pub mExistingEntry: bool,

--- a/tests/expectations/tests/issue-1514.rs
+++ b/tests/expectations/tests/issue-1514.rs
@@ -12,6 +12,7 @@ pub struct Thing {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("Thing::Inner")]
 pub struct Thing_Inner<T> {
     pub ptr: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
@@ -23,6 +24,7 @@ impl<T> Default for Thing_Inner<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("Thing::AnotherInner")]
 pub struct Thing_AnotherInner<T> {
     pub _base: Thing_Inner<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,

--- a/tests/expectations/tests/issue-358.rs
+++ b/tests/expectations/tests/issue-358.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("PersistentRooted")]
 pub struct JS_PersistentRooted {
     pub _base: a,
 }

--- a/tests/expectations/tests/issue-493.rs
+++ b/tests/expectations/tests/issue-493.rs
@@ -58,6 +58,7 @@ pub type basic_string_value_type = ::std::os::raw::c_char;
 pub type basic_string_pointer = *mut basic_string_value_type;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("basic_string::__long")]
 pub struct basic_string___long {
     pub __cap_: basic_string_size_type,
     pub __size_: basic_string_size_type,
@@ -76,6 +77,7 @@ pub enum basic_string__bindgen_ty_1 {
     __min_cap = 0,
 }
 #[repr(C)]
+#[bindgen_original_name("basic_string::__short")]
 pub struct basic_string___short {
     pub __bindgen_anon_1: basic_string___short__bindgen_ty_1,
     pub __data_: *mut basic_string_value_type,
@@ -97,6 +99,7 @@ impl Default for basic_string___short {
 }
 #[repr(C)]
 #[repr(align(1))]
+#[bindgen_original_name("basic_string::__ulx")]
 pub struct basic_string___ulx {
     pub __lx: __BindgenUnionField<basic_string___long>,
     pub __lxx: __BindgenUnionField<basic_string___short>,
@@ -116,6 +119,7 @@ pub enum basic_string__bindgen_ty_2 {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("basic_string::__raw")]
 pub struct basic_string___raw {
     pub __words: *mut basic_string_size_type,
 }
@@ -125,6 +129,7 @@ impl Default for basic_string___raw {
     }
 }
 #[repr(C)]
+#[bindgen_original_name("basic_string::__rep")]
 pub struct basic_string___rep {
     pub __bindgen_anon_1: basic_string___rep__bindgen_ty_1,
 }

--- a/tests/expectations/tests/issue-493_1_0.rs
+++ b/tests/expectations/tests/issue-493_1_0.rs
@@ -58,6 +58,7 @@ pub type basic_string_value_type = ::std::os::raw::c_char;
 pub type basic_string_pointer = *mut basic_string_value_type;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("basic_string::__long")]
 pub struct basic_string___long {
     pub __cap_: basic_string_size_type,
     pub __size_: basic_string_size_type,
@@ -77,6 +78,7 @@ pub enum basic_string__bindgen_ty_1 {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("basic_string::__short")]
 pub struct basic_string___short {
     pub __bindgen_anon_1: basic_string___short__bindgen_ty_1,
     pub __data_: *mut basic_string_value_type,
@@ -95,6 +97,7 @@ impl Default for basic_string___short {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("basic_string::__ulx")]
 pub struct basic_string___ulx {
     pub __lx: __BindgenUnionField<basic_string___long>,
     pub __lxx: __BindgenUnionField<basic_string___short>,
@@ -109,6 +112,7 @@ pub enum basic_string__bindgen_ty_2 {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("basic_string::__raw")]
 pub struct basic_string___raw {
     pub __words: *mut basic_string_size_type,
 }
@@ -119,6 +123,7 @@ impl Default for basic_string___raw {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("basic_string::__rep")]
 pub struct basic_string___rep {
     pub __bindgen_anon_1: basic_string___rep__bindgen_ty_1,
 }

--- a/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -16,6 +16,7 @@ pub enum _bindgen_ty_1 {
 pub type JS_Alias = u8;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("Base")]
 pub struct JS_Base {
     pub f: JS_Alias,
 }
@@ -26,6 +27,7 @@ impl Default for JS_Base {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("AutoIdVector")]
 pub struct JS_AutoIdVector {
     pub _base: JS_Base,
 }

--- a/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -12,6 +12,7 @@ pub struct Foo {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("Foo::Bar")]
 pub struct Foo_Bar {
     pub abc: ::std::os::raw::c_int,
 }
@@ -63,6 +64,7 @@ pub struct Baz {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("Baz::Bar")]
 pub struct Baz_Bar {
     pub abc: ::std::os::raw::c_int,
 }

--- a/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -45,6 +45,7 @@ pub struct rte_ring {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("rte_ring::prod")]
 pub struct rte_ring_prod {
     pub watermark: ::std::os::raw::c_uint,
 }
@@ -76,6 +77,7 @@ fn bindgen_test_layout_rte_ring_prod() {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("rte_ring::cons")]
 pub struct rte_ring_cons {
     pub sc_dequeue: ::std::os::raw::c_uint,
 }

--- a/tests/expectations/tests/maddness-is-avoidable.rs
+++ b/tests/expectations/tests/maddness-is-avoidable.rs
@@ -12,6 +12,7 @@ pub struct RefPtr {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("RefPtr::Proxy")]
 pub struct RefPtr_Proxy {
     pub _address: u8,
 }

--- a/tests/expectations/tests/nsBaseHashtable.rs
+++ b/tests/expectations/tests/nsBaseHashtable.rs
@@ -26,6 +26,7 @@ pub type nsBaseHashtable_KeyType = [u8; 0usize];
 pub type nsBaseHashtable_EntryType = nsBaseHashtableET;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("nsBaseHashtable::LookupResult")]
 pub struct nsBaseHashtable_LookupResult {
     pub mEntry: *mut nsBaseHashtable_EntryType,
     pub mTable: *mut nsBaseHashtable,
@@ -37,6 +38,7 @@ impl Default for nsBaseHashtable_LookupResult {
 }
 #[repr(C)]
 #[derive(Debug)]
+#[bindgen_original_name("nsBaseHashtable::EntryPtr")]
 pub struct nsBaseHashtable_EntryPtr {
     pub mEntry: *mut nsBaseHashtable_EntryType,
     pub mExistingEntry: bool,

--- a/tests/expectations/tests/public-dtor.rs
+++ b/tests/expectations/tests/public-dtor.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Default)]
+#[bindgen_original_name("String")]
 pub struct cv_String {
     pub _address: u8,
 }

--- a/tests/expectations/tests/replace_template_alias.rs
+++ b/tests/expectations/tests/replace_template_alias.rs
@@ -11,6 +11,7 @@
 pub type JS_detail_MaybeWrapped<T> = T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("Rooted")]
 pub struct JS_Rooted<T> {
     pub ptr: JS_detail_MaybeWrapped<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,

--- a/tests/expectations/tests/replaces_double.rs
+++ b/tests/expectations/tests/replaces_double.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("Wrapper::Wrapped")]
 pub struct Wrapper_Wrapped<T> {
     pub t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,

--- a/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -7,11 +7,13 @@
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("Zone")]
 pub struct JS_Zone {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("Zone")]
 pub struct JS_shadow_Zone {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,

--- a/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -19,6 +19,7 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
+        #[bindgen_original_name("Wrapper::sentry")]
         pub struct Wrapper_sentry {
             pub i_am_wrapper_sentry: ::std::os::raw::c_int,
         }
@@ -73,6 +74,7 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
+        #[bindgen_original_name("NotTemplateWrapper::sentry")]
         pub struct NotTemplateWrapper_sentry {
             pub i_am_not_template_wrapper_sentry: ::std::os::raw::c_char,
         }
@@ -110,6 +112,7 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
+        #[bindgen_original_name("InlineNotTemplateWrapper::sentry")]
         pub struct InlineNotTemplateWrapper_sentry {
             pub i_am_inline_not_template_wrapper_sentry: bool,
         }
@@ -166,6 +169,7 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
+        #[bindgen_original_name("InlineTemplateWrapper::sentry")]
         pub struct InlineTemplateWrapper_sentry {
             pub i_am_inline_template_wrapper_sentry: ::std::os::raw::c_int,
         }
@@ -176,6 +180,7 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
+        #[bindgen_original_name("OuterDoubleWrapper::InnerDoubleWrapper")]
         pub struct OuterDoubleWrapper_InnerDoubleWrapper {
             pub _address: u8,
         }
@@ -213,6 +218,9 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
+        #[bindgen_original_name(
+            "OuterDoubleWrapper::InnerDoubleWrapper::sentry"
+        )]
         pub struct OuterDoubleWrapper_InnerDoubleWrapper_sentry {
             pub i_am_double_wrapper_sentry: ::std::os::raw::c_int,
         }
@@ -262,11 +270,17 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
+        #[bindgen_original_name(
+            "OuterDoubleInlineWrapper::InnerDoubleInlineWrapper"
+        )]
         pub struct OuterDoubleInlineWrapper_InnerDoubleInlineWrapper {
             pub _address: u8,
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
+        #[bindgen_original_name(
+            "OuterDoubleInlineWrapper::InnerDoubleInlineWrapper::sentry"
+        )]
         pub struct OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry {
             pub i_am_double_wrapper_inline_sentry: ::std::os::raw::c_int,
         }
@@ -326,6 +340,7 @@ pub mod root {
     }
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
+    #[bindgen_original_name("OutsideNamespaceWrapper::sentry")]
     pub struct OutsideNamespaceWrapper_sentry {
         pub i_am_outside_namespace_wrapper_sentry: ::std::os::raw::c_int,
     }

--- a/tests/expectations/tests/template-fun-ty.rs
+++ b/tests/expectations/tests/template-fun-ty.rs
@@ -19,6 +19,7 @@ pub struct RefPtr {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("RefPtr::Proxy")]
 pub struct RefPtr_Proxy {
     pub _address: u8,
 }

--- a/tests/expectations/tests/template-param-usage-10.rs
+++ b/tests/expectations/tests/template-param-usage-10.rs
@@ -16,6 +16,7 @@ pub type DoublyIndirectUsage_Aliased<T> = T;
 pub type DoublyIndirectUsage_Typedefed<U> = U;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("DoublyIndirectUsage::IndirectUsage")]
 pub struct DoublyIndirectUsage_IndirectUsage<T, U> {
     pub member: DoublyIndirectUsage_Aliased<T>,
     pub another: DoublyIndirectUsage_Typedefed<U>,

--- a/tests/expectations/tests/template-param-usage-2.rs
+++ b/tests/expectations/tests/template-param-usage-2.rs
@@ -13,6 +13,7 @@ pub struct UsesTemplateParameter<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("UsesTemplateParameter::AlsoUsesTemplateParameter")]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameter<T> {
     pub also: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,

--- a/tests/expectations/tests/template-param-usage-3.rs
+++ b/tests/expectations/tests/template-param-usage-3.rs
@@ -13,6 +13,9 @@ pub struct UsesTemplateParameter<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name(
+    "UsesTemplateParameter::AlsoUsesTemplateParameterAndMore"
+)]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameterAndMore<T, U> {
     pub also: T,
     pub more: U,

--- a/tests/expectations/tests/template-param-usage-4.rs
+++ b/tests/expectations/tests/template-param-usage-4.rs
@@ -13,6 +13,7 @@ pub struct UsesTemplateParameter<T> {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[bindgen_original_name("UsesTemplateParameter::DoesNotUseTemplateParameters")]
 pub struct UsesTemplateParameter_DoesNotUseTemplateParameters {
     pub x: ::std::os::raw::c_int,
 }

--- a/tests/expectations/tests/template-param-usage-9.rs
+++ b/tests/expectations/tests/template-param-usage-9.rs
@@ -14,6 +14,7 @@ pub type DoesNotUse_Aliased<T> = T;
 pub type DoesNotUse_Typedefed<U> = U;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("DoesNotUse::IndirectUsage")]
 pub struct DoesNotUse_IndirectUsage<T, U> {
     pub member: DoesNotUse_Aliased<T>,
     pub another: DoesNotUse_Typedefed<U>,

--- a/tests/expectations/tests/template_alias.rs
+++ b/tests/expectations/tests/template_alias.rs
@@ -8,6 +8,7 @@
 pub type JS_detail_Wrapped<T> = T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("Rooted")]
 pub struct JS_Rooted<T> {
     pub ptr: JS_detail_Wrapped<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,

--- a/tests/expectations/tests/template_typedef_transitive_param.rs
+++ b/tests/expectations/tests/template_typedef_transitive_param.rs
@@ -12,6 +12,7 @@ pub struct Wrapper {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("Wrapper::Wrapped")]
 pub struct Wrapper_Wrapped<T> {
     pub t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,

--- a/tests/expectations/tests/templateref_opaque.rs
+++ b/tests/expectations/tests/templateref_opaque.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("PointerType")]
 pub struct detail_PointerType {
     pub _address: u8,
 }

--- a/tests/expectations/tests/transform-op.rs
+++ b/tests/expectations/tests/transform-op.rs
@@ -77,6 +77,7 @@ pub const StyleFoo_Tag_Bazz: StyleFoo_Tag = 0;
 pub type StyleFoo_Tag = u8;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("StyleFoo::Foo_Body")]
 pub struct StyleFoo_Foo_Body<T> {
     pub tag: StyleFoo_Tag,
     pub x: i32,
@@ -91,6 +92,7 @@ impl<T> Default for StyleFoo_Foo_Body<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("StyleFoo::Bar_Body")]
 pub struct StyleFoo_Bar_Body<T> {
     pub tag: StyleFoo_Tag,
     pub _0: T,
@@ -103,6 +105,7 @@ impl<T> Default for StyleFoo_Bar_Body<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("StyleFoo::Baz_Body")]
 pub struct StyleFoo_Baz_Body<T> {
     pub tag: StyleFoo_Tag,
     pub _0: StylePoint<T>,
@@ -137,6 +140,7 @@ pub const StyleBar_Tag_Bar4: StyleBar_Tag = 0;
 pub type StyleBar_Tag = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("StyleBar::StyleBar1_Body")]
 pub struct StyleBar_StyleBar1_Body<T> {
     pub x: i32,
     pub y: StylePoint<T>,
@@ -150,6 +154,7 @@ impl<T> Default for StyleBar_StyleBar1_Body<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("StyleBar::StyleBar2_Body")]
 pub struct StyleBar_StyleBar2_Body<T> {
     pub _0: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
@@ -161,6 +166,7 @@ impl<T> Default for StyleBar_StyleBar2_Body<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[bindgen_original_name("StyleBar::StyleBar3_Body")]
 pub struct StyleBar_StyleBar3_Body<T> {
     pub _0: StylePoint<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,

--- a/tests/expectations/tests/typeref.rs
+++ b/tests/expectations/tests/typeref.rs
@@ -7,6 +7,7 @@
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("FragmentOrURL")]
 pub struct mozilla_FragmentOrURL {
     pub mIsLocalRef: bool,
 }
@@ -38,6 +39,7 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("Position")]
 pub struct mozilla_Position {
     pub _address: u8,
 }
@@ -55,6 +57,7 @@ fn bindgen_test_layout_mozilla_Position() {
     );
 }
 #[repr(C)]
+#[bindgen_original_name("StyleShapeSource")]
 pub struct mozilla_StyleShapeSource {
     pub __bindgen_anon_1: mozilla_StyleShapeSource__bindgen_ty_1,
 }

--- a/tests/expectations/tests/typeref_1_0.rs
+++ b/tests/expectations/tests/typeref_1_0.rs
@@ -50,6 +50,7 @@ impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
 impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
+#[bindgen_original_name("FragmentOrURL")]
 pub struct mozilla_FragmentOrURL {
     pub mIsLocalRef: bool,
 }
@@ -86,6 +87,7 @@ impl Clone for mozilla_FragmentOrURL {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
+#[bindgen_original_name("Position")]
 pub struct mozilla_Position {
     pub _address: u8,
 }
@@ -109,6 +111,7 @@ impl Clone for mozilla_Position {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[bindgen_original_name("StyleShapeSource")]
 pub struct mozilla_StyleShapeSource {
     pub __bindgen_anon_1: mozilla_StyleShapeSource__bindgen_ty_1,
 }


### PR DESCRIPTION
When I added the `bindgen_original_name` attribute for nested structs, I only updated expectations for a few tests that seemed most relevant. When I now attempted to update expectations for all tests, I noticed that `bindgen_original_name` was being emitted for anonymous structs containing `_bindgen_ty_1` etc., which of course is not a valid C++ type.

The attribute will now only be emitted for structs that are named and whose entire chain of ancestors is also named.

The change also updates test expectations to give a clean baseline, except for the following tests, which would change more than just attributes and may indeed be indicative of bugs:

header_template_hpp
header_template_param_usage_15_hpp