### PR TITLE
Switch from attributes to callbacks.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen-tests"
+version = "0.1.0"
+dependencies = [
+ "autocxx-bindgen",
+ "owo-colors",
+ "prettyplease",
+ "proc-macro2",
+ "regex",
+ "shlex",
+ "similar",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +200,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+ "windows-targets",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +303,18 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "prettyplease"
@@ -319,10 +380,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "strsim"
@@ -342,6 +422,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +452,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -431,3 +534,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "bindgen",
     #"bindgen-cli",
     #"bindgen-integration",
-    #"bindgen-tests",
+    "bindgen-tests",
     #"bindgen-tests/tests/quickchecking",
     #"bindgen-tests/tests/expectations",
 ]
@@ -22,7 +22,7 @@ edition = "2021"
 # All dependency version management is centralized here
 [workspace.dependencies]
 annotate-snippets = "0.11.4"
-bindgen = { version = "0.71.1", path = "./bindgen", default-features = false }
+autocxx-bindgen = { version = "0.71.1", path = "./bindgen", default-features = false }
 bitflags = "2.2.1"
 block = "0.1"
 cc = "1.0"

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dev-dependencies]
-bindgen = { workspace = true, default-features = true, features = ["__cli", "experimental"] }
+autocxx-bindgen = { workspace = true, default-features = true, features = ["__cli", "experimental"] }
 owo-colors.workspace = true
 prettyplease = { workspace = true, features = ["verbatim"] }
 proc-macro2.workspace = true
@@ -19,10 +19,10 @@ syn.workspace = true
 tempfile.workspace = true
 
 [features]
-logging = ["bindgen/logging"]
-static = ["bindgen/static"]
-runtime = ["bindgen/runtime"]
+logging = ["autocxx-bindgen/logging"]
+static = ["autocxx-bindgen/static"]
+runtime = ["autocxx-bindgen/runtime"]
 
-__testing_only_extra_assertions = ["bindgen/__testing_only_extra_assertions"]
-__testing_only_libclang_9 = ["bindgen/__testing_only_libclang_9"]
-__testing_only_libclang_16 = ["bindgen/__testing_only_libclang_16"]
+__testing_only_extra_assertions = ["autocxx-bindgen/__testing_only_extra_assertions"]
+__testing_only_libclang_9 = ["autocxx-bindgen/__testing_only_libclang_9"]
+__testing_only_libclang_16 = ["autocxx-bindgen/__testing_only_libclang_16"]

--- a/bindgen-tests/tests/expectations/tests/381-decltype-alias.rs
+++ b/bindgen-tests/tests/expectations/tests/381-decltype-alias.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("allocator_traits")]
 pub struct std_allocator_traits {
     pub _address: u8,
 }
-#[bindgen_original_name("allocator_traits::__size_type")]
 pub type std_allocator_traits___size_type<_Alloc> = _Alloc;

--- a/bindgen-tests/tests/expectations/tests/allowlist_basic.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist_basic.rs
@@ -8,7 +8,6 @@ pub struct AllowlistMe<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("AllowlistMe::Inner")]
 pub struct AllowlistMe_Inner<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub bar: T,

--- a/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
@@ -4,13 +4,9 @@
 pub struct DataType {
     pub _address: u8,
 }
-#[bindgen_original_name("DataType::value_type")]
 pub type DataType_value_type<_Tp> = _Tp;
-#[bindgen_original_name("DataType::work_type")]
 pub type DataType_work_type<_Tp> = DataType_value_type<_Tp>;
-#[bindgen_original_name("DataType::channel_type")]
 pub type DataType_channel_type<_Tp> = DataType_value_type<_Tp>;
-#[bindgen_original_name("DataType::vec_type")]
 pub type DataType_vec_type<_Tp> = DataType_value_type<_Tp>;
 pub const DataType_generic_type: DataType__bindgen_ty_1 = DataType__bindgen_ty_1::generic_type;
 pub const DataType_depth: DataType__bindgen_ty_1 = DataType__bindgen_ty_1::generic_type;

--- a/bindgen-tests/tests/expectations/tests/anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_union.rs
@@ -10,20 +10,17 @@ impl TErrorResult_UnionState {
     pub const HasException: TErrorResult_UnionState = TErrorResult_UnionState::HasMessage;
 }
 #[repr(i32)]
-#[bindgen_original_name("TErrorResult::UnionState")]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum TErrorResult_UnionState {
     HasMessage = 0,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("TErrorResult::Message")]
 pub struct TErrorResult_Message {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("TErrorResult::DOMExceptionInfo")]
 pub struct TErrorResult_DOMExceptionInfo {
     _unused: [u8; 0],
 }

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
@@ -11,7 +11,6 @@ fn bindgen_test_layout_Foo() {
 }
 extern "C" {
     #[must_use]
-    #[bindgen_original_name("foo")]
     #[link_name = "\u{1}_ZN3Foo3fooEi"]
     pub fn Foo_foo(this: *mut Foo, arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
@@ -10,7 +10,6 @@ fn bindgen_test_layout_Foo() {
     assert_eq!(::std::mem::align_of::<Foo>(), 1usize, "Alignment of Foo");
 }
 extern "C" {
-    #[bindgen_original_name("foo")]
     #[link_name = "\u{1}_ZN3Foo3fooEi"]
     pub fn Foo_foo(this: *mut Foo, arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }

--- a/bindgen-tests/tests/expectations/tests/bad-namespace-parenthood-inheritance.rs
+++ b/bindgen-tests/tests/expectations/tests/bad-namespace-parenthood-inheritance.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("char_traits")]
 pub struct std_char_traits {
     pub _address: u8,
 }
@@ -16,7 +15,6 @@ impl Default for std_char_traits {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("char_traits")]
 pub struct __gnu_cxx_char_traits {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -153,17 +153,14 @@ const _: () = {
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("type")]
     #[link_name = "\u{1}_ZN3Foo4typeEv"]
     pub fn Foo_type(this: *mut Foo) -> ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    #[bindgen_original_name("set_type_")]
     #[link_name = "\u{1}_ZN3Foo9set_type_Ec"]
     pub fn Foo_set_type_(this: *mut Foo, c: ::std::os::raw::c_char);
 }
 unsafe extern "C" {
-    #[bindgen_original_name("set_type")]
     #[link_name = "\u{1}_ZN3Foo8set_typeEc"]
     pub fn Foo_set_type(this: *mut Foo, c: ::std::os::raw::c_char);
 }

--- a/bindgen-tests/tests/expectations/tests/builtin-template.rs
+++ b/bindgen-tests/tests/expectations/tests/builtin-template.rs
@@ -1,3 +1,2 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[bindgen_original_name("make_integer_sequence")]
 pub type std_make_integer_sequence = u8;

--- a/bindgen-tests/tests/expectations/tests/call-conv-typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/call-conv-typedef.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![cfg(not(test))]
 pub type void_fn = ::std::option::Option<unsafe extern "stdcall" fn()>;
-#[bindgen_original_name("fn")]
 pub type fn_ = ::std::option::Option<
     unsafe extern "stdcall" fn(id: ::std::os::raw::c_int) -> void_fn,
 >;

--- a/bindgen-tests/tests/expectations/tests/class_nested.rs
+++ b/bindgen-tests/tests/expectations/tests/class_nested.rs
@@ -6,7 +6,6 @@ pub struct A {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("A::B")]
 pub struct A_B {
     pub member_b: ::std::os::raw::c_int,
 }
@@ -18,7 +17,6 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("A::D")]
 pub struct A_D<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub foo: T,
@@ -40,7 +38,6 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("A::C")]
 pub struct A_C {
     pub baz: ::std::os::raw::c_int,
 }
@@ -84,7 +81,6 @@ pub struct Templated<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("Templated::Templated_inner")]
 pub struct Templated_Templated_inner<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub member_ptr: *mut T,

--- a/bindgen-tests/tests/expectations/tests/class_with_enum.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_enum.rs
@@ -1,10 +1,4 @@
-#![allow(
-    dead_code,
-    non_snake_case,
-    non_camel_case_types,
-    non_upper_case_globals
-)]
-
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct A {
@@ -12,18 +6,9 @@ pub struct A {
 }
 pub const A_B_B1: A_B = 0;
 pub const A_B_B2: A_B = 1;
-#[bindgen_original_name("A::B")]
 pub type A_B = ::std::os::raw::c_uint;
-#[test]
-fn bindgen_test_layout_A() {
-    assert_eq!(
-        ::std::mem::size_of::<A>(),
-        1usize,
-        concat!("Size of: ", stringify!(A))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        1usize,
-        concat!("Alignment of ", stringify!(A))
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
@@ -9,9 +9,7 @@ pub struct C {
     pub d: AnotherInt,
     pub other_ptr: *mut AnotherInt,
 }
-#[bindgen_original_name("C::MyInt")]
 pub type C_MyInt = ::std::os::raw::c_int;
-#[bindgen_original_name("C::Lookup")]
 pub type C_Lookup = *const ::std::os::raw::c_char;
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -24,24 +22,18 @@ const _: () = {
     ["Offset of field: C::other_ptr"][::std::mem::offset_of!(C, other_ptr) - 64usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("method")]
     #[link_name = "\u{1}_ZN1C6methodEi"]
     pub fn C_method(this: *mut C, c: C_MyInt);
 }
 unsafe extern "C" {
-    #[bindgen_arg_type_reference(c)]
-    #[bindgen_original_name("methodRef")]
     #[link_name = "\u{1}_ZN1C9methodRefERi"]
     pub fn C_methodRef(this: *mut C, c: *mut C_MyInt);
 }
 unsafe extern "C" {
-    #[bindgen_arg_type_reference(c)]
-    #[bindgen_original_name("complexMethodRef")]
     #[link_name = "\u{1}_ZN1C16complexMethodRefERPKc"]
     pub fn C_complexMethodRef(this: *mut C, c: *mut C_Lookup);
 }
 unsafe extern "C" {
-    #[bindgen_original_name("anotherMethod")]
     #[link_name = "\u{1}_ZN1C13anotherMethodEi"]
     pub fn C_anotherMethod(this: *mut C, c: AnotherInt);
 }
@@ -59,12 +51,10 @@ impl C {
     pub unsafe fn method(&mut self, c: C_MyInt) {
         C_method(self, c)
     }
-    #[bindgen_arg_type_reference(c)]
     #[inline]
     pub unsafe fn methodRef(&mut self, c: *mut C_MyInt) {
         C_methodRef(self, c)
     }
-    #[bindgen_arg_type_reference(c)]
     #[inline]
     pub unsafe fn complexMethodRef(&mut self, c: *mut C_Lookup) {
         C_complexMethodRef(self, c)

--- a/bindgen-tests/tests/expectations/tests/comment-indent.rs
+++ b/bindgen-tests/tests/expectations/tests/comment-indent.rs
@@ -16,7 +16,6 @@ pub mod root {
  This class is not so interesting, but worth a bit of docs too!*/
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
-    #[bindgen_original_name("Foo::Bar")]
     pub struct Foo_Bar {
         pub _address: u8,
     }

--- a/bindgen-tests/tests/expectations/tests/constant-non-specialized-tp.rs
+++ b/bindgen-tests/tests/expectations/tests/constant-non-specialized-tp.rs
@@ -11,7 +11,6 @@ pub struct Outer {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("Outer::Inner")]
 pub struct Outer_Inner {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/constructor-tp.rs
+++ b/bindgen-tests/tests/expectations/tests/constructor-tp.rs
@@ -15,8 +15,6 @@ const _: () = {
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("Bar")]
-    #[bindgen_special_member("default_ctor")]
     #[link_name = "\u{1}_ZN3BarC1Ev"]
     pub fn Bar_Bar(this: *mut Bar);
 }

--- a/bindgen-tests/tests/expectations/tests/constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors.rs
@@ -10,7 +10,6 @@ const _: () = {
     ["Alignment of TestOverload"][::std::mem::align_of::<TestOverload>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("TestOverload")]
     #[link_name = "\u{1}_ZN12TestOverloadC1Ei"]
     pub fn TestOverload_TestOverload(
         this: *mut TestOverload,
@@ -18,7 +17,6 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
-    #[bindgen_original_name("TestOverload")]
     #[link_name = "\u{1}_ZN12TestOverloadC1Ed"]
     pub fn TestOverload_TestOverload1(this: *mut TestOverload, arg1: f64);
 }
@@ -49,8 +47,6 @@ const _: () = {
     ][::std::mem::align_of::<TestPublicNoArgs>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("TestPublicNoArgs")]
-    #[bindgen_special_member("default_ctor")]
     #[link_name = "\u{1}_ZN16TestPublicNoArgsC1Ev"]
     pub fn TestPublicNoArgs_TestPublicNoArgs(this: *mut TestPublicNoArgs);
 }

--- a/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
@@ -15,7 +15,6 @@ fn bindgen_test_layout_TestOverload() {
 }
 extern "C" {
     /// Calling this should use `mem::unintialized()` and not `MaybeUninit()` as only rust 1.36 includes that.
-    #[bindgen_original_name("TestOverload")]
     #[link_name = "\u{1}_ZN12TestOverloadC1Ei"]
     pub fn TestOverload_TestOverload(
         this: *mut TestOverload,
@@ -24,7 +23,6 @@ extern "C" {
 }
 extern "C" {
     /// Calling this should use `mem::unintialized()` and not `MaybeUninit()` as only rust 1.36 includes that.
-    #[bindgen_original_name("TestOverload")]
     #[link_name = "\u{1}_ZN12TestOverloadC1Ed"]
     pub fn TestOverload_TestOverload1(this: *mut TestOverload, arg1: f64);
 }
@@ -61,8 +59,6 @@ fn bindgen_test_layout_TestPublicNoArgs() {
     );
 }
 extern "C" {
-    #[bindgen_original_name("TestPublicNoArgs")]
-    #[bindgen_special_member("default_ctor")]
     #[link_name = "\u{1}_ZN16TestPublicNoArgsC1Ev"]
     pub fn TestPublicNoArgs_TestPublicNoArgs(this: *mut TestPublicNoArgs);
 }

--- a/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -111,17 +111,14 @@ fn bindgen_test_layout_Foo() {
     );
 }
 extern "C" {
-    #[bindgen_original_name("type")]
     #[link_name = "\u{1}_ZN3Foo4typeEv"]
     pub fn Foo_type(this: *mut Foo) -> ::std::os::raw::c_char;
 }
 extern "C" {
-    #[bindgen_original_name("set_type_")]
     #[link_name = "\u{1}_ZN3Foo9set_type_Ec"]
     pub fn Foo_set_type_(this: *mut Foo, c: ::std::os::raw::c_char);
 }
 extern "C" {
-    #[bindgen_original_name("set_type")]
     #[link_name = "\u{1}_ZN3Foo8set_typeEc"]
     pub fn Foo_set_type(this: *mut Foo, c: ::std::os::raw::c_char);
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -5,7 +5,6 @@ pub struct Nice {
     pub pointer: Nice_Function,
     pub large_array: [::std::os::raw::c_int; 34usize],
 }
-#[bindgen_original_name("Nice::Function")]
 pub type Nice_Function = ::std::option::Option<
     unsafe extern "C" fn(data: ::std::os::raw::c_int),
 >;

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -11,17 +11,14 @@ const _: () = {
     ["Offset of field: X::_x"][::std::mem::offset_of!(X, _x) - 0usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("some_function")]
     #[link_name = "\u{1}_ZN1X13some_functionEv"]
     pub fn X_some_function(this: *mut X);
 }
 unsafe extern "C" {
-    #[bindgen_original_name("some_other_function")]
     #[link_name = "\u{1}_ZN1X19some_other_functionEv"]
     pub fn X_some_other_function(this: *mut X);
 }
 unsafe extern "C" {
-    #[bindgen_original_name("X")]
     #[link_name = "\u{1}_ZN1XC1Ei"]
     pub fn X_X(this: *mut X, x: ::std::os::raw::c_int);
 }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -11,17 +11,14 @@ const _: () = {
     ["Offset of field: A::_x"][::std::mem::offset_of!(A, _x) - 0usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("some_function")]
     #[link_name = "\u{1}_ZN1A13some_functionEv"]
     pub fn A_some_function(this: *mut A);
 }
 unsafe extern "C" {
-    #[bindgen_original_name("some_other_function")]
     #[link_name = "\u{1}_ZN1A19some_other_functionEv"]
     pub fn A_some_other_function(this: *mut A);
 }
 unsafe extern "C" {
-    #[bindgen_original_name("A")]
     #[link_name = "\u{1}_ZN1AC1Ei"]
     pub fn A_A(this: *mut A, x: ::std::os::raw::c_int);
 }

--- a/bindgen-tests/tests/expectations/tests/elaborated.rs
+++ b/bindgen-tests/tests/expectations/tests/elaborated.rs
@@ -1,4 +1,4 @@
-#[bindgen_original_name("whatever_t")]
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub type whatever_whatever_t = ::std::os::raw::c_int;
 unsafe extern "C" {
     #[link_name = "\u{1}_Z9somethingPKi"]

--- a/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -33,7 +33,6 @@ impl Default for C {
     }
 }
 unsafe extern "C" {
-    #[bindgen_original_name("match")]
     #[link_name = "\u{1}_ZN1C5matchEv"]
     pub fn C_match(this: *mut ::std::os::raw::c_void);
 }

--- a/bindgen-tests/tests/expectations/tests/enum_in_template.rs
+++ b/bindgen-tests/tests/expectations/tests/enum_in_template.rs
@@ -6,5 +6,4 @@ pub struct Foo {
 }
 pub const Foo_Bar_A: Foo_Bar = 0;
 pub const Foo_Bar_B: Foo_Bar = 0;
-#[bindgen_original_name("Foo::Bar")]
 pub type Foo_Bar = i32;

--- a/bindgen-tests/tests/expectations/tests/enum_in_template_with_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/enum_in_template_with_typedef.rs
@@ -1,17 +1,14 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("fbstring_core")]
 pub struct std_fbstring_core {
     pub _address: u8,
 }
-#[bindgen_original_name("fbstring_core::category_type")]
 pub type std_fbstring_core_category_type = u8;
 impl std_fbstring_core_Category {
     pub const Bar: std_fbstring_core_Category = std_fbstring_core_Category::Foo;
 }
 #[repr(u8)]
-#[bindgen_original_name("fbstring_core::Category")]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum std_fbstring_core_Category {
     Foo = 0,

--- a/bindgen-tests/tests/expectations/tests/eval-value-dependent.rs
+++ b/bindgen-tests/tests/expectations/tests/eval-value-dependent.rs
@@ -4,5 +4,4 @@
 pub struct e {
     pub _address: u8,
 }
-#[bindgen_original_name("e::f")]
 pub type e_f<d> = d;

--- a/bindgen-tests/tests/expectations/tests/forward-inherit-struct-with-fields.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-inherit-struct-with-fields.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("RootedBase")]
 pub struct js_RootedBase<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub foo: *mut T,

--- a/bindgen-tests/tests/expectations/tests/forward-inherit-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-inherit-struct.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("RootedBase")]
 pub struct js_RootedBase {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/gen-constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors.rs
@@ -10,7 +10,6 @@ const _: () = {
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("Foo")]
     #[link_name = "\u{1}_ZN3FooC1Ei"]
     pub fn Foo_Foo(this: *mut Foo, a: ::std::os::raw::c_int);
 }

--- a/bindgen-tests/tests/expectations/tests/gen-destructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-destructors.rs
@@ -11,8 +11,6 @@ const _: () = {
     ["Offset of field: Foo::bar"][::std::mem::offset_of!(Foo, bar) - 0usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("Foo_destructor")]
-    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN3FooD1Ev"]
     pub fn Foo_Foo_destructor(this: *mut Foo);
 }

--- a/bindgen-tests/tests/expectations/tests/generate-inline.rs
+++ b/bindgen-tests/tests/expectations/tests/generate-inline.rs
@@ -10,7 +10,6 @@ const _: () = {
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("bar")]
     #[link_name = "\u{1}_ZN3Foo3barEv"]
     pub fn Foo_bar() -> ::std::os::raw::c_int;
 }

--- a/bindgen-tests/tests/expectations/tests/in_class_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/in_class_typedef.rs
@@ -4,13 +4,10 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[bindgen_original_name("Foo::elem_type")]
 pub type Foo_elem_type<T> = T;
-#[bindgen_original_name("Foo::ptr_type")]
 pub type Foo_ptr_type<T> = *mut T;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("Foo::Bar")]
 pub struct Foo_Bar {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/inherit-namespaced.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit-namespaced.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("RootedBase")]
 pub struct js_RootedBase {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug)]
-#[bindgen_original_name("basic_string")]
 pub struct std_basic_string<CharT> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<CharT>>,
     pub hider: std_basic_string_Alloc_hider,
@@ -10,7 +9,6 @@ pub struct std_basic_string<CharT> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("basic_string::Alloc_hider")]
 pub struct std_basic_string_Alloc_hider {
     pub storage: *mut ::std::os::raw::c_void,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1113-template-references.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1113-template-references.rs
@@ -21,11 +21,9 @@ impl<K, V> Default for Entry<K, V> {
 pub struct nsBaseHashtable {
     pub _address: u8,
 }
-#[bindgen_original_name("nsBaseHashtable::EntryType")]
 pub type nsBaseHashtable_EntryType<K, V> = Entry<K, V>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("nsBaseHashtable::EntryPtr")]
 pub struct nsBaseHashtable_EntryPtr<K, V> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<K>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,

--- a/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[bindgen_unused_template_param]
 pub type c = nsTArray;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -60,7 +59,6 @@ impl Default for nsIContent {
     }
 }
 unsafe extern "C" {
-    #[bindgen_unused_template_param_in_arg_or_return]
     #[link_name = "\u{1}_Z35Gecko_GetAnonymousContentForElementv"]
     pub fn Gecko_GetAnonymousContentForElement() -> *mut nsTArray;
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
@@ -20,16 +20,3 @@ impl Default for Foo {
         }
     }
 }
-extern "C" {
-    #[bindgen_pure_virtual]
-    #[bindgen_original_name("Bar")]
-    #[link_name = "\u{1}_ZN3Foo3BarEv"]
-    pub fn Foo_Bar(this: *mut ::std::os::raw::c_void);
-}
-extern "C" {
-    #[bindgen_pure_virtual]
-    #[bindgen_original_name("Foo_destructor")]
-    #[bindgen_special_member("dtor")]
-    #[link_name = "\u{1}_ZN3FooD1Ev"]
-    pub fn Foo_Foo_destructor(this: *mut Foo);
-}

--- a/bindgen-tests/tests/expectations/tests/issue-1350-attribute-overloadable.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1350-attribute-overloadable.rs
@@ -4,7 +4,6 @@ unsafe extern "C" {
     pub fn my_function(a: ::std::os::raw::c_int);
 }
 unsafe extern "C" {
-    #[bindgen_original_name("my_function")]
     #[link_name = "\u{1}_Z11my_functionPKc"]
     pub fn my_function1(a: *const ::std::os::raw::c_char);
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1514.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1514.rs
@@ -6,7 +6,6 @@ pub struct Thing {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("Thing::Inner")]
 pub struct Thing_Inner<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub ptr: *mut T,
@@ -22,7 +21,6 @@ impl<T> Default for Thing_Inner<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("Thing::AnotherInner")]
 pub struct Thing_AnotherInner<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _base: Thing_Inner<T>,

--- a/bindgen-tests/tests/expectations/tests/issue-2019.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2019.rs
@@ -32,7 +32,6 @@ const _: () = {
     ["Offset of field: B::b"][::std::mem::offset_of!(B, b) - 0usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("make")]
     #[link_name = "\u{1}_ZN1B4makeEv"]
     pub fn make1() -> B;
 }

--- a/bindgen-tests/tests/expectations/tests/issue-358.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-358.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("PersistentRooted")]
 pub struct JS_PersistentRooted {
     pub _base: a,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-410.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-410.rs
@@ -17,7 +17,6 @@ pub mod root {
             ["Alignment of Value"][::std::mem::align_of::<Value>() - 1usize];
         };
         unsafe extern "C" {
-            #[bindgen_original_name("a")]
             #[link_name = "\u{1}_ZN2JS5Value1aE10JSWhyMagic"]
             pub fn Value_a(this: *mut root::JS::Value, arg1: root::JSWhyMagic);
         }

--- a/bindgen-tests/tests/expectations/tests/issue-447.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-447.rs
@@ -40,7 +40,6 @@ pub mod root {
         ][::std::mem::align_of::<JSAutoCompartment>() - 1usize];
     };
     unsafe extern "C" {
-        #[bindgen_original_name("JSAutoCompartment")]
         #[link_name = "\u{1}_ZN17JSAutoCompartmentC1EN7mozilla6detail19GuardObjectNotifierE"]
         pub fn JSAutoCompartment_JSAutoCompartment(
             this: *mut root::JSAutoCompartment,

--- a/bindgen-tests/tests/expectations/tests/issue-493.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-493.rs
@@ -47,15 +47,11 @@ impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 pub struct basic_string {
     pub _address: u8,
 }
-#[bindgen_original_name("basic_string::size_type")]
 pub type basic_string_size_type = ::std::os::raw::c_ulonglong;
-#[bindgen_original_name("basic_string::value_type")]
 pub type basic_string_value_type = ::std::os::raw::c_char;
-#[bindgen_original_name("basic_string::pointer")]
 pub type basic_string_pointer = *mut basic_string_value_type;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("basic_string::__long")]
 pub struct basic_string___long {
     pub __cap_: basic_string_size_type,
     pub __size_: basic_string_size_type,
@@ -77,7 +73,6 @@ pub enum basic_string__bindgen_ty_1 {
     __min_cap = 0,
 }
 #[repr(C)]
-#[bindgen_original_name("basic_string::__short")]
 pub struct basic_string___short {
     pub __bindgen_anon_1: basic_string___short__bindgen_ty_1,
     pub __data_: *mut basic_string_value_type,
@@ -107,7 +102,6 @@ impl Default for basic_string___short {
 }
 #[repr(C)]
 #[repr(align(1))]
-#[bindgen_original_name("basic_string::__ulx")]
 pub struct basic_string___ulx {
     pub __lx: __BindgenUnionField<basic_string___long>,
     pub __lxx: __BindgenUnionField<basic_string___short>,
@@ -130,7 +124,6 @@ pub enum basic_string__bindgen_ty_2 {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("basic_string::__raw")]
 pub struct basic_string___raw {
     pub __words: *mut basic_string_size_type,
 }
@@ -144,7 +137,6 @@ impl Default for basic_string___raw {
     }
 }
 #[repr(C)]
-#[bindgen_original_name("basic_string::__rep")]
 pub struct basic_string___rep {
     pub __bindgen_anon_1: basic_string___rep__bindgen_ty_1,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce-2.rs
@@ -14,9 +14,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
 pub struct Foo {
     pub member: *mut Foo_SecondAlias,
 }
-#[bindgen_original_name("Foo::FirstAlias")]
 pub type Foo_FirstAlias = __BindgenOpaqueArray<u8, 0usize>;
-#[bindgen_original_name("Foo::SecondAlias")]
 pub type Foo_SecondAlias = Foo;
 impl Default for Foo {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -7,11 +7,9 @@ pub enum _bindgen_ty_1 {
     ENUM_VARIANT_1 = 0,
     ENUM_VARIANT_2 = 1,
 }
-#[bindgen_original_name("Alias")]
 pub type JS_Alias = u8;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("Base")]
 pub struct JS_Base {
     pub f: JS_Alias,
 }
@@ -26,7 +24,6 @@ impl Default for JS_Base {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("AutoIdVector")]
 pub struct JS_AutoIdVector {
     pub _base: JS_Base,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -5,7 +5,6 @@ pub type RefPtr<T> = T;
 pub struct A {
     pub _address: u8,
 }
-#[bindgen_original_name("A::a")]
 pub type A_a = b;
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {

--- a/bindgen-tests/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
@@ -20,7 +20,6 @@ pub struct UsesRefPtrWithAliasedTypeParam<U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
     pub member: RefPtr<UsesRefPtrWithAliasedTypeParam_V<U>>,
 }
-#[bindgen_original_name("UsesRefPtrWithAliasedTypeParam::V")]
 pub type UsesRefPtrWithAliasedTypeParam_V<U> = U;
 impl<U> Default for UsesRefPtrWithAliasedTypeParam<U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -6,7 +6,6 @@ pub struct Foo {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("Foo::Bar")]
 pub struct Foo_Bar {
     pub abc: ::std::os::raw::c_int,
 }
@@ -29,7 +28,6 @@ pub struct Baz {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("Baz::Bar")]
 pub struct Baz_Bar {
     pub abc: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-645-cannot-find-type-T-in-this-scope.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-645-cannot-find-type-T-in-this-scope.rs
@@ -6,7 +6,6 @@ pub struct HasRefPtr<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub refptr_member: RefPtr<HasRefPtr_TypedefOfT<T>>,
 }
-#[bindgen_original_name("HasRefPtr::TypedefOfT")]
 pub type HasRefPtr_TypedefOfT<T> = T;
 impl<T> Default for HasRefPtr<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-674-1.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-1.rs
@@ -11,7 +11,6 @@ pub mod root {
         pub struct Maybe {
             pub _address: u8,
         }
-        #[bindgen_original_name("Maybe::ValueType")]
         pub type Maybe_ValueType<T> = T;
     }
     #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/issue-674-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-2.rs
@@ -11,7 +11,6 @@ pub mod root {
         pub struct Rooted {
             pub _address: u8,
         }
-        #[bindgen_original_name("Rooted::ElementType")]
         pub type Rooted_ElementType<T> = T;
     }
     #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/issue-674-3.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-3.rs
@@ -8,7 +8,6 @@ pub mod root {
     pub struct nsRefPtrHashtable {
         pub _address: u8,
     }
-    #[bindgen_original_name("nsRefPtrHashtable::UserDataType")]
     pub type nsRefPtrHashtable_UserDataType<PtrType> = *mut PtrType;
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]

--- a/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -41,12 +41,10 @@ const _: () = {
     ["Alignment of Opaque"][::std::mem::align_of::<Opaque>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("eleven_out_of_ten")]
     #[link_name = "\u{1}_ZN6Opaque17eleven_out_of_tenEv"]
     pub fn Opaque_eleven_out_of_ten(this: *mut Opaque) -> SuchWow;
 }
 unsafe extern "C" {
-    #[bindgen_original_name("Opaque")]
     #[link_name = "\u{1}_ZN6OpaqueC1E6Pupper"]
     pub fn Opaque_Opaque(this: *mut Opaque, pup: Pupper);
 }

--- a/bindgen-tests/tests/expectations/tests/issue-820-unused-template-param-in-alias.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-820-unused-template-param-in-alias.rs
@@ -1,3 +1,2 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[bindgen_original_name("Foo::self_type")]
 pub type Foo_self_type = u8;

--- a/bindgen-tests/tests/expectations/tests/issue-833-1.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-833-1.rs
@@ -4,6 +4,5 @@ pub struct nsTArray {
     pub hdr: *const (),
 }
 unsafe extern "C" {
-    #[bindgen_unused_template_param_in_arg_or_return]
     pub fn func() -> *mut nsTArray;
 }

--- a/bindgen-tests/tests/expectations/tests/maddness-is-avoidable.rs
+++ b/bindgen-tests/tests/expectations/tests/maddness-is-avoidable.rs
@@ -6,7 +6,6 @@ pub struct RefPtr {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("RefPtr::Proxy")]
 pub struct RefPtr_Proxy {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/method-mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/method-mangling.rs
@@ -10,7 +10,6 @@ const _: () = {
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("type")]
     #[link_name = "\u{1}_ZN3Foo4typeEv"]
     pub fn Foo_type(this: *mut Foo) -> ::std::os::raw::c_int;
 }

--- a/bindgen-tests/tests/expectations/tests/nested.rs
+++ b/bindgen-tests/tests/expectations/tests/nested.rs
@@ -17,14 +17,12 @@ pub struct Test {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("Test::Size")]
 pub struct Test_Size {
     pub mWidth: Test_Size_Dimension,
     pub mHeight: Test_Size_Dimension,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("Test::Size::Dimension")]
 pub struct Test_Size_Dimension {
     pub _base: Calc,
 }

--- a/bindgen-tests/tests/expectations/tests/nested_vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_vtable.rs
@@ -25,7 +25,6 @@ impl Default for nsISupports {
     }
 }
 unsafe extern "C" {
-    #[bindgen_original_name("QueryInterface")]
     #[link_name = "\u{1}_ZN11nsISupports14QueryInterfaceEv"]
     pub fn nsISupports_QueryInterface(
         this: *mut ::std::os::raw::c_void,

--- a/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
@@ -13,7 +13,6 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
-        #[bindgen_original_name("Bar::Baz")]
         pub struct Bar_Baz {
             pub foo: ::std::os::raw::c_int,
         }

--- a/bindgen-tests/tests/expectations/tests/nsBaseHashtable.rs
+++ b/bindgen-tests/tests/expectations/tests/nsBaseHashtable.rs
@@ -24,14 +24,10 @@ pub struct nsTHashtable {
 pub struct nsBaseHashtable {
     pub _address: u8,
 }
-#[bindgen_original_name("nsBaseHashtable::KeyType")]
 pub type nsBaseHashtable_KeyType = __BindgenOpaqueArray<u8, 0usize>;
-#[bindgen_unused_template_param]
-#[bindgen_original_name("nsBaseHashtable::EntryType")]
 pub type nsBaseHashtable_EntryType = nsBaseHashtableET;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("nsBaseHashtable::LookupResult")]
 pub struct nsBaseHashtable_LookupResult {
     pub mEntry: *mut nsBaseHashtable_EntryType,
     pub mTable: *mut nsBaseHashtable,
@@ -47,7 +43,6 @@ impl Default for nsBaseHashtable_LookupResult {
 }
 #[repr(C)]
 #[derive(Debug)]
-#[bindgen_original_name("nsBaseHashtable::EntryPtr")]
 pub struct nsBaseHashtable_EntryPtr {
     pub mEntry: *mut nsBaseHashtable_EntryType,
     pub mExistingEntry: bool,

--- a/bindgen-tests/tests/expectations/tests/nsStyleAutoArray.rs
+++ b/bindgen-tests/tests/expectations/tests/nsStyleAutoArray.rs
@@ -22,7 +22,6 @@ pub struct nsStyleAutoArray<T> {
     pub mOtherElements: nsTArray<T>,
 }
 #[repr(i32)]
-#[bindgen_original_name("nsStyleAutoArray::WithSingleInitialElement")]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum nsStyleAutoArray_WithSingleInitialElement {
     WITH_SINGLE_INITIAL_ELEMENT = 0,

--- a/bindgen-tests/tests/expectations/tests/opaque_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_typedef.rs
@@ -6,5 +6,4 @@ pub struct RandomTemplate {
 }
 /// <div rustbindgen opaque></div>
 pub type ShouldBeOpaque = u8;
-#[bindgen_unused_template_param]
 pub type ShouldNotBeOpaque = RandomTemplate;

--- a/bindgen-tests/tests/expectations/tests/overloading.rs
+++ b/bindgen-tests/tests/expectations/tests/overloading.rs
@@ -4,17 +4,14 @@ unsafe extern "C" {
     pub fn Evaluate(r: ::std::os::raw::c_char) -> bool;
 }
 unsafe extern "C" {
-    #[bindgen_original_name("Evaluate")]
     #[link_name = "\u{1}_Z8Evaluateii"]
     pub fn Evaluate1(x: ::std::os::raw::c_int, y: ::std::os::raw::c_int) -> bool;
 }
 unsafe extern "C" {
-    #[bindgen_original_name("MyFunction")]
     #[link_name = "\u{1}_ZN3foo10MyFunctionEv"]
     pub fn foo_MyFunction();
 }
 unsafe extern "C" {
-    #[bindgen_original_name("MyFunction")]
     #[link_name = "\u{1}_ZN3bar10MyFunctionEv"]
     pub fn bar_MyFunction();
 }

--- a/bindgen-tests/tests/expectations/tests/packed-vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-vtable.rs
@@ -25,8 +25,6 @@ impl Default for PackedVtable {
     }
 }
 extern "C" {
-    #[bindgen_original_name("PackedVtable_destructor")]
-    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN12PackedVtableD1Ev"]
     pub fn PackedVtable_PackedVtable_destructor(this: *mut PackedVtable);
 }

--- a/bindgen-tests/tests/expectations/tests/public-dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/public-dtor.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Default)]
-#[bindgen_original_name("Foo")]
 pub struct cv_Foo {
     pub _address: u8,
 }
@@ -11,8 +10,6 @@ const _: () = {
     ["Alignment of cv_Foo"][::std::mem::align_of::<cv_Foo>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("Foo_destructor")]
-    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN2cv3FooD1Ev"]
     pub fn cv_Foo_Foo_destructor(this: *mut cv_Foo);
 }

--- a/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
+++ b/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
@@ -27,8 +27,6 @@ impl Default for nsID {
     }
 }
 unsafe extern "C" {
-    #[bindgen_arg_type_reference(aDest)]
-    #[bindgen_original_name("ToProvidedString")]
     #[link_name = "\u{1}_ZN4nsID16ToProvidedStringERA10_c"]
     pub fn nsID_ToProvidedString(
         this: *mut ::std::os::raw::c_void,

--- a/bindgen-tests/tests/expectations/tests/replace_template_alias.rs
+++ b/bindgen-tests/tests/expectations/tests/replace_template_alias.rs
@@ -2,11 +2,9 @@
 /** But the replacement type does use T!
 
  <div rustbindgen replaces="JS::detail::MaybeWrapped" />*/
-#[bindgen_original_name("MaybeWrapped")]
 pub type JS_detail_MaybeWrapped<T> = T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("Rooted")]
 pub struct JS_Rooted<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub ptr: JS_detail_MaybeWrapped<T>,

--- a/bindgen-tests/tests/expectations/tests/replaces_double.rs
+++ b/bindgen-tests/tests/expectations/tests/replaces_double.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("Wrapper::Wrapped")]
 pub struct Wrapper_Wrapped<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: T,
@@ -15,7 +14,6 @@ impl<T> Default for Wrapper_Wrapped<T> {
         }
     }
 }
-#[bindgen_original_name("Wrapper::Type")]
 pub type Wrapper_Type<T> = Wrapper_Wrapped<T>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -24,7 +22,6 @@ pub struct Rooted<T> {
     pub ptr: Rooted_MaybeWrapped<T>,
 }
 /// <div rustbindgen replaces="Rooted_MaybeWrapped"></div>
-#[bindgen_original_name("Rooted::Rooted_MaybeWrapped")]
 pub type Rooted_MaybeWrapped<T> = T;
 impl<T> Default for Rooted<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -13,7 +13,6 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
-        #[bindgen_original_name("Wrapper::sentry")]
         pub struct Wrapper_sentry {
             pub i_am_wrapper_sentry: ::std::os::raw::c_int,
         }
@@ -46,7 +45,6 @@ pub mod root {
         };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
-        #[bindgen_original_name("NotTemplateWrapper::sentry")]
         pub struct NotTemplateWrapper_sentry {
             pub i_am_not_template_wrapper_sentry: ::std::os::raw::c_char,
         }
@@ -71,7 +69,6 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
-        #[bindgen_original_name("InlineNotTemplateWrapper::sentry")]
         pub struct InlineNotTemplateWrapper_sentry {
             pub i_am_inline_not_template_wrapper_sentry: bool,
         }
@@ -105,7 +102,6 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
-        #[bindgen_original_name("InlineTemplateWrapper::sentry")]
         pub struct InlineTemplateWrapper_sentry {
             pub i_am_inline_template_wrapper_sentry: ::std::os::raw::c_int,
         }
@@ -116,7 +112,6 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
-        #[bindgen_original_name("OuterDoubleWrapper::InnerDoubleWrapper")]
         pub struct OuterDoubleWrapper_InnerDoubleWrapper {
             pub _address: u8,
         }
@@ -140,9 +135,6 @@ pub mod root {
         };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
-        #[bindgen_original_name(
-            "OuterDoubleWrapper::InnerDoubleWrapper::sentry"
-        )]
         pub struct OuterDoubleWrapper_InnerDoubleWrapper_sentry {
             pub i_am_double_wrapper_sentry: ::std::os::raw::c_int,
         }
@@ -169,17 +161,11 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
-        #[bindgen_original_name(
-            "OuterDoubleInlineWrapper::InnerDoubleInlineWrapper"
-        )]
         pub struct OuterDoubleInlineWrapper_InnerDoubleInlineWrapper {
             pub _address: u8,
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
-        #[bindgen_original_name(
-            "OuterDoubleInlineWrapper::InnerDoubleInlineWrapper::sentry"
-        )]
         pub struct OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry {
             pub i_am_double_wrapper_inline_sentry: ::std::os::raw::c_int,
         }
@@ -230,7 +216,6 @@ pub mod root {
     }
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
-    #[bindgen_original_name("OutsideNamespaceWrapper::sentry")]
     pub struct OutsideNamespaceWrapper_sentry {
         pub i_am_outside_namespace_wrapper_sentry: ::std::os::raw::c_int,
     }

--- a/bindgen-tests/tests/expectations/tests/special-members.rs
+++ b/bindgen-tests/tests/expectations/tests/special-members.rs
@@ -1,51 +1,27 @@
-#![allow(
-    dead_code,
-    non_snake_case,
-    non_camel_case_types,
-    non_upper_case_globals
-)]
-
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct A {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    assert_eq!(
-        ::std::mem::size_of::<A>(),
-        1usize,
-        concat!("Size of: ", stringify!(A))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        1usize,
-        concat!("Alignment of ", stringify!(A))
-    );
-}
-extern "C" {
-    #[bindgen_original_name("A")]
-    #[bindgen_special_member("default_ctor")]
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+};
+unsafe extern "C" {
     #[link_name = "\u{1}_ZN1AC1Ev"]
     pub fn A_A(this: *mut A);
 }
-extern "C" {
-    #[bindgen_arg_type_reference(arg1)]
-    #[bindgen_original_name("A")]
-    #[bindgen_special_member("copy_ctor")]
+unsafe extern "C" {
     #[link_name = "\u{1}_ZN1AC1ERS_"]
     pub fn A_A1(this: *mut A, arg1: *mut A);
 }
-extern "C" {
-    #[bindgen_arg_type_reference(arg1)]
-    #[bindgen_original_name("A")]
-    #[bindgen_special_member("move_ctor")]
+unsafe extern "C" {
     #[link_name = "\u{1}_ZN1AC1EOS_"]
     pub fn A_A2(this: *mut A, arg1: *mut A);
 }
-extern "C" {
-    #[bindgen_original_name("A_destructor")]
-    #[bindgen_special_member("dtor")]
+unsafe extern "C" {
     #[link_name = "\u{1}_ZN1AD1Ev"]
     pub fn A_A_destructor(this: *mut A);
 }
@@ -56,14 +32,12 @@ impl A {
         A_A(__bindgen_tmp.as_mut_ptr());
         __bindgen_tmp.assume_init()
     }
-    #[bindgen_arg_type_reference(arg1)]
     #[inline]
     pub unsafe fn new1(arg1: *mut A) -> Self {
         let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
         A_A1(__bindgen_tmp.as_mut_ptr(), arg1);
         __bindgen_tmp.assume_init()
     }
-    #[bindgen_arg_type_reference(arg1)]
     #[inline]
     pub unsafe fn new2(arg1: *mut A) -> Self {
         let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();

--- a/bindgen-tests/tests/expectations/tests/struct_with_typedef_template_arg.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_typedef_template_arg.rs
@@ -4,5 +4,4 @@
 pub struct Proxy {
     pub _address: u8,
 }
-#[bindgen_original_name("Proxy::foo")]
 pub type Proxy_foo<T> = ::std::option::Option<unsafe extern "C" fn(bar: *mut T)>;

--- a/bindgen-tests/tests/expectations/tests/template-fun-ty.rs
+++ b/bindgen-tests/tests/expectations/tests/template-fun-ty.rs
@@ -4,7 +4,6 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[bindgen_original_name("Foo::FunctionPtr")]
 pub type Foo_FunctionPtr<T> = ::std::option::Option<unsafe extern "C" fn() -> T>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -13,11 +12,9 @@ pub struct RefPtr {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("RefPtr::Proxy")]
 pub struct RefPtr_Proxy {
     pub _address: u8,
 }
-#[bindgen_original_name("RefPtr::Proxy::member_function")]
 pub type RefPtr_Proxy_member_function<R, Args> = ::std::option::Option<
     unsafe extern "C" fn(arg1: Args) -> R,
 >;

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-10.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-10.rs
@@ -6,13 +6,10 @@ pub struct DoublyIndirectUsage<T, U> {
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
     pub doubly_indirect: DoublyIndirectUsage_IndirectUsage<T, U>,
 }
-#[bindgen_original_name("DoublyIndirectUsage::Aliased")]
 pub type DoublyIndirectUsage_Aliased<T> = T;
-#[bindgen_original_name("DoublyIndirectUsage::Typedefed")]
 pub type DoublyIndirectUsage_Typedefed<U> = U;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("DoublyIndirectUsage::IndirectUsage")]
 pub struct DoublyIndirectUsage_IndirectUsage<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-2.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-2.rs
@@ -7,7 +7,6 @@ pub struct UsesTemplateParameter<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("UsesTemplateParameter::AlsoUsesTemplateParameter")]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameter<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub also: T,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-3.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-3.rs
@@ -7,9 +7,6 @@ pub struct UsesTemplateParameter<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name(
-    "UsesTemplateParameter::AlsoUsesTemplateParameterAndMore"
-)]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameterAndMore<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-4.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-4.rs
@@ -7,7 +7,6 @@ pub struct UsesTemplateParameter<T> {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[bindgen_original_name("UsesTemplateParameter::DoesNotUseTemplateParameters")]
 pub struct UsesTemplateParameter_DoesNotUseTemplateParameters {
     pub x: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-5.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-5.rs
@@ -5,7 +5,6 @@ pub struct IndirectlyUsesTemplateParameter<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub aliased: IndirectlyUsesTemplateParameter_Aliased<T>,
 }
-#[bindgen_original_name("IndirectlyUsesTemplateParameter::Aliased")]
 pub type IndirectlyUsesTemplateParameter_Aliased<T> = T;
 impl<T> Default for IndirectlyUsesTemplateParameter<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-6.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-6.rs
@@ -4,5 +4,4 @@
 pub struct DoesNotUseTemplateParameter {
     pub x: ::std::os::raw::c_int,
 }
-#[bindgen_original_name("DoesNotUseTemplateParameter::ButAliasDoesUseIt")]
 pub type DoesNotUseTemplateParameter_ButAliasDoesUseIt<T> = T;

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-7.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-7.rs
@@ -16,5 +16,4 @@ impl<T, V> Default for DoesNotUseU<T, V> {
         }
     }
 }
-#[bindgen_unused_template_param]
 pub type Alias = DoesNotUseU<::std::os::raw::c_int, ::std::os::raw::c_char>;

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-8.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-8.rs
@@ -7,9 +7,7 @@ pub struct IndirectUsage<T, U> {
     pub member1: IndirectUsage_Typedefed<T>,
     pub member2: IndirectUsage_Aliased<U>,
 }
-#[bindgen_original_name("IndirectUsage::Typedefed")]
 pub type IndirectUsage_Typedefed<T> = T;
-#[bindgen_original_name("IndirectUsage::Aliased")]
 pub type IndirectUsage_Aliased<U> = U;
 impl<T, U> Default for IndirectUsage<T, U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-9.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-9.rs
@@ -4,13 +4,10 @@
 pub struct DoesNotUse {
     pub _address: u8,
 }
-#[bindgen_original_name("DoesNotUse::Aliased")]
 pub type DoesNotUse_Aliased<T> = T;
-#[bindgen_original_name("DoesNotUse::Typedefed")]
 pub type DoesNotUse_Typedefed<U> = U;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("DoesNotUse::IndirectUsage")]
 pub struct DoesNotUse_IndirectUsage<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,

--- a/bindgen-tests/tests/expectations/tests/template_alias.rs
+++ b/bindgen-tests/tests/expectations/tests/template_alias.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[bindgen_original_name("Wrapped")]
 pub type JS_detail_Wrapped<T> = T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("Rooted")]
 pub struct JS_Rooted<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub ptr: JS_detail_Wrapped<T>,

--- a/bindgen-tests/tests/expectations/tests/template_typedef_transitive_param.rs
+++ b/bindgen-tests/tests/expectations/tests/template_typedef_transitive_param.rs
@@ -6,7 +6,6 @@ pub struct Wrapper {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("Wrapper::Wrapped")]
 pub struct Wrapper_Wrapped<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: T,
@@ -20,5 +19,4 @@ impl<T> Default for Wrapper_Wrapped<T> {
         }
     }
 }
-#[bindgen_original_name("Wrapper::Type")]
 pub type Wrapper_Type<T> = Wrapper_Wrapped<T>;

--- a/bindgen-tests/tests/expectations/tests/template_typedefs.rs
+++ b/bindgen-tests/tests/expectations/tests/template_typedefs.rs
@@ -5,11 +5,8 @@ pub type foo = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::
 pub struct Foo {
     pub _address: u8,
 }
-#[bindgen_original_name("Foo::Char")]
 pub type Foo_Char<T> = T;
-#[bindgen_original_name("Foo::FooPtrTypedef")]
 pub type Foo_FooPtrTypedef<T> = *mut Foo_Char<T>;
-#[bindgen_original_name("Foo::nsCOMArrayEnumFunc")]
 pub type Foo_nsCOMArrayEnumFunc<T> = ::std::option::Option<
     unsafe extern "C" fn(aElement: *mut T, aData: *mut ::std::os::raw::c_void) -> bool,
 >;

--- a/bindgen-tests/tests/expectations/tests/templateref_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/templateref_opaque.rs
@@ -1,17 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("PointerType")]
 pub struct detail_PointerType {
     pub _address: u8,
 }
-#[bindgen_original_name("PointerType::Type")]
 pub type detail_PointerType_Type<T> = *mut T;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct UniquePtr {
     pub _address: u8,
 }
-#[bindgen_unused_template_param]
-#[bindgen_original_name("UniquePtr::Pointer")]
 pub type UniquePtr_Pointer = detail_PointerType;

--- a/bindgen-tests/tests/expectations/tests/transform-op.rs
+++ b/bindgen-tests/tests/expectations/tests/transform-op.rs
@@ -72,11 +72,9 @@ pub const StyleFoo_Tag_Foo: StyleFoo_Tag = 0;
 pub const StyleFoo_Tag_Bar: StyleFoo_Tag = 0;
 pub const StyleFoo_Tag_Baz: StyleFoo_Tag = 0;
 pub const StyleFoo_Tag_Bazz: StyleFoo_Tag = 0;
-#[bindgen_original_name("StyleFoo::Tag")]
 pub type StyleFoo_Tag = u8;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("StyleFoo::Foo_Body")]
 pub struct StyleFoo_Foo_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleFoo_Tag,
@@ -95,7 +93,6 @@ impl<T> Default for StyleFoo_Foo_Body<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("StyleFoo::Bar_Body")]
 pub struct StyleFoo_Bar_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleFoo_Tag,
@@ -112,7 +109,6 @@ impl<T> Default for StyleFoo_Bar_Body<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("StyleFoo::Baz_Body")]
 pub struct StyleFoo_Baz_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleFoo_Tag,
@@ -160,11 +156,9 @@ pub const StyleBar_Tag_Bar1: StyleBar_Tag = 0;
 pub const StyleBar_Tag_Bar2: StyleBar_Tag = 0;
 pub const StyleBar_Tag_Bar3: StyleBar_Tag = 0;
 pub const StyleBar_Tag_Bar4: StyleBar_Tag = 0;
-#[bindgen_original_name("StyleBar::Tag")]
 pub type StyleBar_Tag = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("StyleBar::StyleBar1_Body")]
 pub struct StyleBar_StyleBar1_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub x: i32,
@@ -182,7 +176,6 @@ impl<T> Default for StyleBar_StyleBar1_Body<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("StyleBar::StyleBar2_Body")]
 pub struct StyleBar_StyleBar2_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _0: T,
@@ -198,7 +191,6 @@ impl<T> Default for StyleBar_StyleBar2_Body<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[bindgen_original_name("StyleBar::StyleBar3_Body")]
 pub struct StyleBar_StyleBar3_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _0: StylePoint<T>,

--- a/bindgen-tests/tests/expectations/tests/typeref.rs
+++ b/bindgen-tests/tests/expectations/tests/typeref.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("FragmentOrURL")]
 pub struct mozilla_FragmentOrURL {
     pub mIsLocalRef: bool,
 }
@@ -19,7 +18,6 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
-#[bindgen_original_name("Position")]
 pub struct mozilla_Position {
     pub _address: u8,
 }
@@ -31,7 +29,6 @@ const _: () = {
     ][::std::mem::align_of::<mozilla_Position>() - 1usize];
 };
 #[repr(C)]
-#[bindgen_original_name("StyleShapeSource")]
 pub struct mozilla_StyleShapeSource {
     pub __bindgen_anon_1: mozilla_StyleShapeSource__bindgen_ty_1,
 }

--- a/bindgen-tests/tests/expectations/tests/union_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/union_dtor.rs
@@ -16,8 +16,6 @@ const _: () = {
     ][::std::mem::offset_of!(UnionWithDtor, mBar) - 0usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("UnionWithDtor_destructor")]
-    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]
     pub fn UnionWithDtor_UnionWithDtor_destructor(this: *mut UnionWithDtor);
 }

--- a/bindgen-tests/tests/expectations/tests/var-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/var-tracing.rs
@@ -11,7 +11,6 @@ const _: () = {
     ["Offset of field: Bar::m_baz"][::std::mem::offset_of!(Bar, m_baz) - 0usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("Bar")]
     #[link_name = "\u{1}_ZN3BarC1Ei"]
     pub fn Bar_Bar(this: *mut Bar, baz: ::std::os::raw::c_int);
 }

--- a/bindgen-tests/tests/expectations/tests/variadic-method.rs
+++ b/bindgen-tests/tests/expectations/tests/variadic-method.rs
@@ -14,7 +14,6 @@ const _: () = {
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("foo")]
     #[link_name = "\u{1}_ZN3Bar3fooEPKcz"]
     pub fn Bar_foo(this: *mut Bar, fmt: *const ::std::os::raw::c_char, ...);
 }

--- a/bindgen-tests/tests/expectations/tests/virtual_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_dtor.rs
@@ -21,8 +21,6 @@ impl Default for nsSlots {
     }
 }
 unsafe extern "C" {
-    #[bindgen_original_name("nsSlots_destructor")]
-    #[bindgen_special_member("dtor")]
     #[link_name = "\u{1}_ZN7nsSlotsD1Ev"]
     pub fn nsSlots_nsSlots_destructor(this: *mut nsSlots);
 }

--- a/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
@@ -24,12 +24,10 @@ impl Default for C {
     }
 }
 unsafe extern "C" {
-    #[bindgen_original_name("do_thing")]
     #[link_name = "\u{1}_ZN1C8do_thingEc"]
     pub fn C_do_thing(this: *mut ::std::os::raw::c_void, arg1: ::std::os::raw::c_char);
 }
 unsafe extern "C" {
-    #[bindgen_original_name("do_thing")]
     #[link_name = "\u{1}_ZN1C8do_thingEi"]
     pub fn C_do_thing1(this: *mut ::std::os::raw::c_void, arg1: ::std::os::raw::c_int);
 }

--- a/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
+++ b/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
@@ -23,7 +23,6 @@ impl Default for Base {
     }
 }
 unsafe extern "C" {
-    #[bindgen_original_name("AsDerived")]
     #[link_name = "\u{1}_ZN4Base9AsDerivedEv"]
     pub fn Base_AsDerived(this: *mut ::std::os::raw::c_void) -> *mut Derived;
 }

--- a/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
+++ b/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
@@ -10,7 +10,6 @@ const _: () = {
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
 };
 unsafe extern "C" {
-    #[bindgen_original_name("Foo")]
     #[link_name = "\u{1}_ZN3FooC1Ei"]
     pub fn Foo_Foo(
         this: *mut Foo,

--- a/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
+++ b/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
@@ -26,5 +26,4 @@ impl<F> Default for PointTyped<F> {
         }
     }
 }
-#[bindgen_unused_template_param]
 pub type IntPoint = PointTyped<f32>;

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
@@ -12,12 +12,10 @@ const _: () = {
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
 };
 unsafe extern "thiscall" {
-    #[bindgen_original_name("test")]
     #[link_name = "\u{1}?test@Foo@@QAEXXZ"]
     pub fn Foo_test(this: *mut Foo);
 }
 unsafe extern "thiscall" {
-    #[bindgen_original_name("test2")]
     #[link_name = "\u{1}?test2@Foo@@QAEHH@Z"]
     pub fn Foo_test2(
         this: *mut Foo,

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.h
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.h
@@ -1,4 +1,4 @@
-// Unions
+// Structs
 void function_using_anonymous_struct(struct {} arg0);
 
 struct NamedStruct {
@@ -14,3 +14,15 @@ union NamedUnion {
 };
 
 typedef union NamedUnion AliasOfNamedUnion;
+
+// Enums
+
+// We don't include an anonymous enum because such enums
+// are not visible outside the function, and thus tend not
+// to be useful - bindgen doesn't handle them for this reason.
+
+enum NamedEnum {
+    Fish,
+};
+
+typedef enum NamedEnum AliasOfNamedEnum;

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 
 use regex::Regex;
 
+use autocxx_bindgen as bindgen;
 use bindgen::callbacks::{DiscoveredItem, DiscoveredItemId, ParseCallbacks};
 use bindgen::Builder;
 
@@ -58,6 +59,19 @@ pub fn test_item_discovery_callback() {
             DiscoveredItem::Alias {
                 alias_name: "AliasOfNamedUnion".to_string(),
                 alias_for: DiscoveredItemId::new(20),
+            },
+        ),
+        (
+            DiscoveredItemId::new(27),
+            DiscoveredItem::Alias {
+                alias_name: "AliasOfNamedEnum".to_string(),
+                alias_for: DiscoveredItemId::new(24),
+            },
+        ),
+        (
+            DiscoveredItemId::new(24),
+            DiscoveredItem::Enum {
+                final_name: "NamedEnum".to_string(),
             },
         ),
         (
@@ -128,6 +142,11 @@ fn compare_item_info(
             expected,
             generated,
         ),
+        DiscoveredItem::Enum { .. } => compare_enum_info(expected_item, generated_item),
+        // DiscoveredItem::Mod { final_name } => todo!(),
+        // DiscoveredItem::Function { final_name } => todo!(),
+        // DiscoveredItem::Method { final_name, parent } => todo!(),
+        _ => true,
     }
 }
 
@@ -203,6 +222,31 @@ pub fn compare_union_info(
         }
         _ => false,
     }
+}
+
+
+pub fn compare_enum_info(
+    expected_item: &DiscoveredItem,
+    generated_item: &DiscoveredItem,
+) -> bool {
+    let DiscoveredItem::Enum {
+        final_name: expected_final_name,
+    } = expected_item
+    else {
+        unreachable!()
+    };
+
+    let DiscoveredItem::Enum {
+        final_name: generated_final_name,
+    } = generated_item
+    else {
+        unreachable!()
+    };
+
+    if !compare_names(expected_final_name, generated_final_name) {
+        return false;
+    }
+    true
 }
 
 pub fn compare_alias_info(

--- a/bindgen-tests/tests/parse_callbacks/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/mod.rs
@@ -1,5 +1,6 @@
 mod item_discovery_callback;
 
+use autocxx_bindgen as bindgen;
 use bindgen::callbacks::*;
 use bindgen::FieldVisibilityKind;
 

--- a/bindgen/codegen/error.rs
+++ b/bindgen/codegen/error.rs
@@ -12,9 +12,6 @@ pub(crate) enum Error {
     /// template specialization).
     InstantiationOfOpaqueType,
 
-    /// Type was a reference not a pointer, but we had nowhere to record that fact.
-    ReferenceButCouldNotRecord,
-
     /// Function ABI is not supported.
     UnsupportedAbi(&'static str),
 
@@ -35,9 +32,6 @@ impl fmt::Display for Error {
             Error::InstantiationOfOpaqueType => {
                 "Instantiation of opaque template type or partial template specialization."
                     .fmt(f)
-            }
-            Error::ReferenceButCouldNotRecord => {
-                "Type was a reference in a context where we only expected other types".fmt(f)
             }
             Error::UnsupportedAbi(abi) => {
                  write!(

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -74,15 +74,20 @@ impl MethodKind {
     }
 }
 
-// The kind of C++ special member.
+/// The kind of C++ special member.
 // TODO: We don't currently cover copy assignment or move assignment operator
 // because libclang doesn't provide a way to query for them.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum SpecialMemberKind {
+    /// The default constructor.
     DefaultConstructor,
+    /// A copy constructor.
     CopyConstructor,
+    /// A move constructor.
     MoveConstructor,
+    /// A destructor.
     Destructor,
+    /// The assignment operator.
     AssignmentOperator,
 }
 

--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -1,6 +1,5 @@
 #![allow(unused_qualifications)] // Clap somehow generates a lot of these
 
-use autocxx_bindgen as bindgen;
 use crate::{
     builder,
     callbacks::{
@@ -253,7 +252,7 @@ struct BindgenCommand {
     /// Avoid including doc comments in the output, see: <https://github.com/rust-lang/rust-bindgen/issues/426>
     #[arg(long)]
     no_doc_comments: bool,
-    /// Disable allowlisting types recursively. This will cause bindgen to emit Rust code that won't compile! See the `bindgen::Builder::allowlist_recursively` method's documentation for details.
+    /// Disable allowlisting types recursively. This will cause bindgen to emit Rust code that won't compile! See the `autocxx_bindgen::Builder::allowlist_recursively` method's documentation for details.
     #[arg(long)]
     no_recursive_allowlist: bool,
     /// Use extern crate instead of use for objc.
@@ -448,10 +447,6 @@ struct BindgenCommand {
     /// Output C++ overloaded operators
     #[arg(long)]
     represent_cxx_operators: bool,
-    /// Output additional attributes denoting the intende semantics of each C++ function and type.
-    /// Useful for downstream code generators.
-    #[arg(long)]
-    cpp_semantic_attributes: bool,
     /// Use distinct char16_t
     #[arg(long)]
     use_distinct_char16_t: bool,
@@ -645,7 +640,6 @@ where
         explicit_padding,
         use_specific_virtual_function_receiver,
         represent_cxx_operators,
-        cpp_semantic_attributes,
         use_distinct_char16_t,
         vtable_generation,
         sort_semantically,
@@ -944,6 +938,9 @@ where
             translate_enum_integer_types,
             c_naming,
             explicit_padding,
+            use_specific_virtual_function_receiver,
+            represent_cxx_operators,
+            use_distinct_char16_t,
             vtable_generation,
             sort_semantically,
             merge_extern_blocks,

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -168,19 +168,6 @@ options! {
         as_args: "--use-specific-virtual-function-receiver",
     },
 
-    /// Whether we should emit C++ semantics attributes.
-    cpp_semantic_attributes: bool {
-        methods: {
-            /// If this is true, add attributes with details of underlying C++ semantics.
-            /// Disabled by default.
-            pub fn cpp_semantic_attributes(mut self, doit: bool) -> Builder {
-                self.options.cpp_semantic_attributes = doit;
-                self
-            }
-        },
-        as_args: "--cpp-semantic-attributes",
-    },
-
     /// Whether we should output information about C++ overloaded operators.
     represent_cxx_operators: bool {
         methods: {
@@ -207,6 +194,79 @@ options! {
         },
         as_args: "--use-distinct-char16-t",
     },
+
+    /// Use a newtype wrapper to clearly denote "opaque" types; that is,
+    /// types where bindgen has generated a type matching the size and
+    /// alignment of the C++ type but without any knowledge of what's
+    /// inside it. The newtype wrapper will be a fake type called
+    /// `bindgen_marker_Opaque`. It's assumed that you will replace this with some
+    /// real sensible newtype wrapper of your own, either by post-processing
+    /// the output of bindgen, or by using a `use` statemet injected using
+    /// `--module-raw-lines` or similar.
+    use_opaque_newtype_wrapper: bool {
+        methods: {
+            /// If this is true, wrap opaque types in a fake newtype
+            /// wrapper which post-processors can replace with something
+            /// more sensible.
+            pub fn use_opaque_newtype_wrapper(mut self, doit: bool) -> Builder {
+                self.options.use_opaque_newtype_wrapper = doit;
+                self
+            }
+        },
+        as_args: "--use-opaque-newtype-wrapper",
+    },
+
+    /// Use a newtype wrapper to clearly denote C++ reference types.
+    /// These are always generated as raw Rust pointers, and so otherwise
+    /// there's no way to distinguish references from pointers.
+    /// The newtype wrapper will be a fake type either called
+    /// `bindgen_marker_Reference` or `bindgen_marker_RVAlueReference`.
+    /// It's assumed that you will replace this with some
+    /// real sensible newtype wrapper of your own, either by post-processing
+    /// the output of bindgen, or by using a `use` statemet injected using
+    /// `--module-raw-lines` or similar.
+    use_reference_newtype_wrapper: bool {
+        methods: {
+            /// If this is true, wrap C++ references in a fake newtype
+            /// wrapper which post-processors can replace with something
+            /// more sensible.
+            pub fn use_reference_newtype_wrapper(mut self, doit: bool) -> Builder {
+                self.options.use_reference_newtype_wrapper = doit;
+                self
+            }
+        },
+        as_args: "--use-reference-newtype-wrapper",
+    },
+
+    /// Use a newtype wrapper to denote types with "missing" C++ template
+    /// arguments. Sometimes bindgen is unable to see the purpose of
+    /// a given template argument, because it doesn't translate to
+    /// a real purpose in the generated Rust code (e.g. for SFINAE type
+    /// tricks for compile-time evaluation on the C++ side). Bindgen
+    /// thus omits these template parameters. But this can cause problems
+    /// for postprocessors which expect to see all template parameters;
+    /// when this option is enabled we denote these types using a newtype
+    /// wrapper.
+    /// The newtype wrapper will be a fake type called
+    /// `bindgen_marker_MissingTemplateParam`.
+    /// It's assumed that you will replace this with some
+    /// real sensible newtype wrapper of your own, either by post-processing
+    /// the output of bindgen, or by using a `use` statemet injected using
+    /// `--module-raw-lines` or similar.
+    use_unused_template_param_newtype_wrapper: bool {
+        methods: {
+            /// If this is true, wrap types that don't have a complete set
+            /// of template parameters in a fake newtype
+            /// wrapper which post-processors can replace with something
+            /// more sensible.
+            pub fn use_unused_template_param_newtype_wrapper(mut self, doit: bool) -> Builder {
+                self.options.use_unused_template_param_newtype_wrapper = doit;
+                self
+            }
+        },
+        as_args: "--use-unused-template-param-newtype-wrapper",
+    },
+
 
     /// Types that have been blocklisted and should not appear anywhere in the generated code.
     blocklisted_types: RegexSet {
@@ -2221,4 +2281,52 @@ options! {
         },
         as_args: "--clang-macro-fallback-build-dir",
     }
+    /// Whether to always report C++ "deleted" functions.
+    generate_deleted_functions: bool {
+        methods: {
+            /// Set whether to generate C++ functions even marked "=deleted"
+            ///
+            /// Although not useful to call these functions, downstream code
+            /// generators may need to know whether they've been deleted in
+            /// order to determine the relocatability of a C++ type.
+            pub fn generate_deleted_functions(mut self, doit: bool) -> Self {
+                self.options.generate_deleted_functions = doit;
+                self
+            }
+
+        },
+        as_args: "--respect-cxx-access-specs",
+    },
+    /// Whether to always report C++ "pure virtual" functions.
+    generate_pure_virtuals: bool {
+        methods: {
+            /// Set whether to generate C++ functions that are pure virtual.
+            ///
+            /// These functions can't be called, so the only reason
+            /// to generate them is if downstream postprocessors
+            /// need to know of their existence.
+            pub fn generate_pure_virtuals(mut self, doit: bool) -> Self {
+                self.options.generate_pure_virtuals = doit;
+                self
+            }
+
+        },
+        as_args: "--generate-pure-virtuals",
+    },
+    /// Whether to always report C++ "private" functions.
+    generate_private_functions: bool {
+        methods: {
+            /// Set whether to generate C++ functions that are private.
+            ///
+            /// These functions can't be called, so the only reason
+            /// to generate them is if downstream postprocessors
+            /// need to know of their existence.
+            pub fn generate_private_functions(mut self, doit: bool) -> Self {
+                self.options.generate_private_functions = doit;
+                self
+            }
+
+        },
+        as_args: "--generate-private-functions",
+    },
 }


### PR DESCRIPTION
This is a major change to autocxx-bindgen which aims to improve maintainability by reducing divergence from upstream bindgen. Specifically, it:

* Significantly reduces the textual diffence
* Makes the remaining changes less invasive, such that merge conflicts should be easier to resolve
* Redoes the changes such that they're more attuned to the current evolution of upstream bindgen, so it may be possible to upstream some or ideally all of these changes. (The ultimate goal is to unfork bindgen!)

See https://github.com/google/autocxx/issues/124 and https://github.com/rust-lang/rust-bindgen/issues/2943 for the background here.

Specifically this change:
* Removes the #[bindgen_semantic_attributes] which were added to all sorts of items. Instead,
* Much more is communicated via the existing ParseCallbacks mechansim.
* In some cases, it's still necessary to annotate individual types - in this case we generate a newtype wrapper instead of attributes.

This commit also re-enables the bindgen test suite. It does not yet add tests for all the above new functionality; that's yet to come.