### PR TITLE
Cherry-pick upstream fix for bad bindings on Clang 22

### DIFF
--- a/bindgen-tests/tests/expectations/tests/nested-class-field.rs
+++ b/bindgen-tests/tests/expectations/tests/nested-class-field.rs
@@ -1,0 +1,22 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct A {
+    pub _address: u8,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+};
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct A_I {
+    pub i: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of A_I"][::std::mem::size_of::<A_I>() - 4usize];
+    ["Alignment of A_I"][::std::mem::align_of::<A_I>() - 4usize];
+    ["Offset of field: A_I::i"][::std::mem::offset_of!(A_I, i) - 0usize];
+};

--- a/bindgen-tests/tests/headers/nested-class-field.hpp
+++ b/bindgen-tests/tests/headers/nested-class-field.hpp
@@ -1,0 +1,7 @@
+class A {
+  class I;
+};
+
+class A::I {
+  int i;
+};

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1226,11 +1226,11 @@ impl Type {
 
     /// Get a cursor pointing to this type's declaration.
     pub(crate) fn declaration(&self) -> Cursor {
-        unsafe {
-            Cursor {
-                x: clang_getTypeDeclaration(self.x),
-            }
-        }
+        let decl = Cursor {
+            x: unsafe { clang_getTypeDeclaration(self.x) },
+        };
+        // Prior to clang 22, the declaration pointed to the definition.
+        decl.definition().unwrap_or(decl)
     }
 
     /// Get the canonical declaration of this type, if it is available.

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -1297,12 +1297,6 @@ impl CompInfo {
         );
 
         let mut cursor = ty.declaration();
-
-        // If there is a definition, that's what we want.
-        if let Some(def) = cursor.definition() {
-            cursor = def;
-        }
-
         let mut kind = Self::kind_from_cursor(&cursor);
         if kind.is_err() {
             if let Some(location) = location {

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -1297,6 +1297,12 @@ impl CompInfo {
         );
 
         let mut cursor = ty.declaration();
+
+        // If there is a definition, that's what we want.
+        if let Some(def) = cursor.definition() {
+            cursor = def;
+        }
+
         let mut kind = Self::kind_from_cursor(&cursor);
         if kind.is_err() {
             if let Some(location) = location {


### PR DESCRIPTION
The upstream PR is rust-lang/rust-bindgen#3278. Without it, my autocxx project fails to compile on Clang 22 (see tchebb/openwv#9) because autocxx generates constructors for abstract classes. I did not fully track down how the badness flows from bindgen up through autocxx, but I suspect that this regression effectively makes autocxx useless for users on Clang 22.